### PR TITLE
feat: diff command showing all branch changes in one view (#21)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -126,6 +126,8 @@ func (c *CLI) ParseAndExecute(args []string) error {
 		return c.handleMerge(args[2:])
 	case "for-each":
 		return c.handleForEach(args[2:])
+	case "diff":
+		return c.handleDiff(args[2:])
 	case "step":
 		return c.handleStep(args[2:])
 	case "completion":
@@ -1651,6 +1653,109 @@ func (c *CLI) handleForEach(args []string) error {
 
 	if failCount > 0 {
 		return fmt.Errorf("%d worktree(s) failed", failCount)
+	}
+
+	return nil
+}
+
+// handleDiff shows all changes on the current branch since it diverged from the
+// default (or specified) base branch: committed, staged, unstaged, and untracked.
+func (c *CLI) handleDiff(args []string) error {
+	fs := flag.NewFlagSet("diff", flag.ExitOnError)
+	base := fs.String("base", "", "Base branch to diff against (default: auto-detect default branch)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: gren diff [options]\n")
+		fmt.Fprintf(fs.Output(), "\nShow all changes since branching from the base branch\n\n")
+		fmt.Fprintf(fs.Output(), "Options:\n")
+		fs.PrintDefaults()
+		fmt.Fprintf(fs.Output(), "\nExamples:\n")
+		fmt.Fprintf(fs.Output(), "  gren diff\n")
+		fmt.Fprintf(fs.Output(), "  gren diff --base main\n")
+		fmt.Fprintf(fs.Output(), "  gren diff | delta\n")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Determine base branch
+	baseBranch := *base
+	if baseBranch == "" {
+		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "origin/HEAD").Output()
+		if err != nil {
+			// fallback: try main then master
+			for _, candidate := range []string{"main", "master"} {
+				if err2 := exec.Command("git", "rev-parse", "--verify", candidate).Run(); err2 == nil {
+					baseBranch = candidate
+					break
+				}
+			}
+		} else {
+			// origin/HEAD -> strip "origin/" prefix
+			baseBranch = strings.TrimSpace(strings.TrimPrefix(string(out), "origin/"))
+		}
+		if baseBranch == "" {
+			return fmt.Errorf("could not determine default branch; use --base to specify one")
+		}
+	}
+
+	// Verify base branch exists
+	if err := exec.Command("git", "rev-parse", "--verify", baseBranch).Run(); err != nil {
+		return fmt.Errorf("base branch %q not found", baseBranch)
+	}
+
+	// Find merge-base (divergence point)
+	mergeBaseOut, err := exec.Command("git", "merge-base", "HEAD", baseBranch).Output()
+	if err != nil {
+		return fmt.Errorf("failed to find merge-base with %q: %w", baseBranch, err)
+	}
+	mergeBase := strings.TrimSpace(string(mergeBaseOut))
+
+	// 1. Committed changes since merge-base
+	committedCmd := exec.Command("git", "diff", mergeBase, "HEAD")
+	committedCmd.Stdout = os.Stdout
+	committedCmd.Stderr = os.Stderr
+	if err := committedCmd.Run(); err != nil {
+		// non-zero exit is normal if there are no committed changes
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			return fmt.Errorf("git diff (committed) failed: %w", err)
+		}
+	}
+
+	// 2. Staged changes (index vs HEAD)
+	stagedCmd := exec.Command("git", "diff", "--cached")
+	stagedCmd.Stdout = os.Stdout
+	stagedCmd.Stderr = os.Stderr
+	if err := stagedCmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			return fmt.Errorf("git diff --cached (staged) failed: %w", err)
+		}
+	}
+
+	// 3. Unstaged changes (working tree vs index)
+	unstagedCmd := exec.Command("git", "diff")
+	unstagedCmd.Stdout = os.Stdout
+	unstagedCmd.Stderr = os.Stderr
+	if err := unstagedCmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			return fmt.Errorf("git diff (unstaged) failed: %w", err)
+		}
+	}
+
+	// 4. Untracked files (shown as new-file diffs)
+	untrackedOut, err := exec.Command("git", "ls-files", "--others", "--exclude-standard").Output()
+	if err != nil {
+		return fmt.Errorf("git ls-files failed: %w", err)
+	}
+	for _, file := range strings.Split(strings.TrimSpace(string(untrackedOut)), "\n") {
+		if file == "" {
+			continue
+		}
+		untrackedCmd := exec.Command("git", "diff", "--no-index", "/dev/null", file)
+		untrackedCmd.Stdout = os.Stdout
+		// git diff --no-index exits 1 when files differ (always for new files), ignore
+		_ = untrackedCmd.Run()
 	}
 
 	return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1682,22 +1682,12 @@ func (c *CLI) handleDiff(args []string) error {
 	// Determine base branch
 	baseBranch := *base
 	if baseBranch == "" {
-		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "origin/HEAD").Output()
-		if err != nil {
-			// fallback: try main then master
-			for _, candidate := range []string{"main", "master"} {
-				if err2 := exec.Command("git", "rev-parse", "--verify", candidate).Run(); err2 == nil {
-					baseBranch = candidate
-					break
-				}
-			}
-		} else {
-			// origin/HEAD -> strip "origin/" prefix
-			baseBranch = strings.TrimSpace(strings.TrimPrefix(string(out), "origin/"))
-		}
-		if baseBranch == "" {
+		ctx := context.Background()
+		recommended, err := c.gitRepo.GetRecommendedBaseBranch(ctx)
+		if err != nil || recommended == "" {
 			return fmt.Errorf("could not determine default branch; use --base to specify one")
 		}
+		baseBranch = recommended
 	}
 
 	// Verify base branch exists
@@ -1717,10 +1707,7 @@ func (c *CLI) handleDiff(args []string) error {
 	committedCmd.Stdout = os.Stdout
 	committedCmd.Stderr = os.Stderr
 	if err := committedCmd.Run(); err != nil {
-		// non-zero exit is normal if there are no committed changes
-		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
-			return fmt.Errorf("git diff (committed) failed: %w", err)
-		}
+		return fmt.Errorf("git diff (committed) failed: %w", err)
 	}
 
 	// 2. Staged changes (index vs HEAD)
@@ -1728,9 +1715,7 @@ func (c *CLI) handleDiff(args []string) error {
 	stagedCmd.Stdout = os.Stdout
 	stagedCmd.Stderr = os.Stderr
 	if err := stagedCmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
-			return fmt.Errorf("git diff --cached (staged) failed: %w", err)
-		}
+		return fmt.Errorf("git diff --cached (staged) failed: %w", err)
 	}
 
 	// 3. Unstaged changes (working tree vs index)
@@ -1738,9 +1723,7 @@ func (c *CLI) handleDiff(args []string) error {
 	unstagedCmd.Stdout = os.Stdout
 	unstagedCmd.Stderr = os.Stderr
 	if err := unstagedCmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
-			return fmt.Errorf("git diff (unstaged) failed: %w", err)
-		}
+		return fmt.Errorf("git diff (unstaged) failed: %w", err)
 	}
 
 	// 4. Untracked files (shown as new-file diffs)
@@ -1752,7 +1735,7 @@ func (c *CLI) handleDiff(args []string) error {
 		if file == "" {
 			continue
 		}
-		untrackedCmd := exec.Command("git", "diff", "--no-index", "/dev/null", file)
+		untrackedCmd := exec.Command("git", "diff", "--no-index", os.DevNull, file)
 		untrackedCmd.Stdout = os.Stdout
 		// git diff --no-index exits 1 when files differ (always for new files), ignore
 		_ = untrackedCmd.Run()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1916,7 +1916,12 @@ func setupDiffRepo(t *testing.T) string {
 	}
 	run(tmpDir, "git", "add", "staged.txt")
 
-	// Unstaged modification
+	// Unstaged modification: first commit the file, then modify without staging
+	if err := os.WriteFile(filepath.Join(tmpDir, "unstaged.txt"), []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(tmpDir, "git", "add", "unstaged.txt")
+	run(tmpDir, "git", "commit", "-m", "add unstaged.txt")
 	if err := os.WriteFile(filepath.Join(tmpDir, "unstaged.txt"), []byte("unstaged change\n"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1869,3 +1869,200 @@ func TestForEachExitCodeOnFailure(t *testing.T) {
 		t.Fatal("expected non-nil error when commands fail")
 	}
 }
+
+// --- diff tests ---
+
+func setupDiffRepo(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	run := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(tmpDir, "git", "init", "-b", "main")
+	run(tmpDir, "git", "config", "user.email", "test@test.com")
+	run(tmpDir, "git", "config", "user.name", "test")
+
+	// Initial commit on main
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("hello\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(tmpDir, "git", "add", ".")
+	run(tmpDir, "git", "commit", "-m", "initial commit")
+
+	// Create feature branch with a committed change
+	run(tmpDir, "git", "checkout", "-b", "feature/test")
+	if err := os.WriteFile(filepath.Join(tmpDir, "committed.txt"), []byte("committed change\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(tmpDir, "git", "add", ".")
+	run(tmpDir, "git", "commit", "-m", "add committed.txt")
+
+	// Stage a change
+	if err := os.WriteFile(filepath.Join(tmpDir, "staged.txt"), []byte("staged change\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(tmpDir, "git", "add", "staged.txt")
+
+	// Unstaged modification
+	if err := os.WriteFile(filepath.Join(tmpDir, "unstaged.txt"), []byte("unstaged change\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Untracked file
+	if err := os.WriteFile(filepath.Join(tmpDir, "untracked.txt"), []byte("untracked\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpDir
+}
+
+func TestDiffShowsCommittedChanges(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		gitRepo := git.NewLocalRepository()
+		configManager := config.NewManager()
+		c := NewCLI(gitRepo, configManager)
+		err := c.ParseAndExecute([]string{"gren", "diff"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "committed.txt") {
+		t.Errorf("expected committed.txt in diff output, got:\n%s", out)
+	}
+}
+
+func TestDiffShowsStagedChanges(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		gitRepo := git.NewLocalRepository()
+		configManager := config.NewManager()
+		c := NewCLI(gitRepo, configManager)
+		err := c.ParseAndExecute([]string{"gren", "diff"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "staged.txt") {
+		t.Errorf("expected staged.txt in diff output, got:\n%s", out)
+	}
+}
+
+func TestDiffShowsUnstagedChanges(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		gitRepo := git.NewLocalRepository()
+		configManager := config.NewManager()
+		c := NewCLI(gitRepo, configManager)
+		err := c.ParseAndExecute([]string{"gren", "diff"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "unstaged.txt") {
+		t.Errorf("expected unstaged.txt in diff output, got:\n%s", out)
+	}
+}
+
+func TestDiffShowsUntrackedFiles(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		gitRepo := git.NewLocalRepository()
+		configManager := config.NewManager()
+		c := NewCLI(gitRepo, configManager)
+		err := c.ParseAndExecute([]string{"gren", "diff"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "untracked.txt") {
+		t.Errorf("expected untracked.txt in diff output, got:\n%s", out)
+	}
+}
+
+func TestDiffCustomBase(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		gitRepo := git.NewLocalRepository()
+		configManager := config.NewManager()
+		c := NewCLI(gitRepo, configManager)
+		err := c.ParseAndExecute([]string{"gren", "diff", "--base", "main"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "committed.txt") {
+		t.Errorf("expected committed.txt when using --base main, got:\n%s", out)
+	}
+}
+
+func TestDiffUnknownBaseReturnsError(t *testing.T) {
+	repoRoot := setupDiffRepo(t)
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	gitRepo := git.NewLocalRepository()
+	configManager := config.NewManager()
+	c := NewCLI(gitRepo, configManager)
+	err := c.ParseAndExecute([]string{"gren", "diff", "--base", "nonexistent-branch-xyz"})
+	if err == nil {
+		t.Fatal("expected error for unknown base branch, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `gren diff` command that shows a comprehensive view of everything changed on the current branch since it diverged from the base branch.

## Changes

- `internal/cli/cli.go`: Added `handleDiff` and routed `diff` in `ParseAndExecute`
- `internal/cli/cli_test.go`: 6 tests + `setupDiffRepo` helper

## How it works

1. Finds merge-base with `git merge-base HEAD <base>`
2. Shows committed changes: `git diff <merge-base> HEAD`
3. Shows staged changes: `git diff --cached`
4. Shows unstaged changes: `git diff`
5. Shows untracked files: `git ls-files --others` + `git diff --no-index /dev/null <file>`

Auto-detects default branch via `origin/HEAD` with `main`/`master` fallback.

## Test plan

- [x] Shows committed changes (`TestDiffShowsCommittedChanges`)
- [x] Shows staged changes (`TestDiffShowsStagedChanges`)
- [x] Shows unstaged changes (`TestDiffShowsUnstagedChanges`)
- [x] Shows untracked files (`TestDiffShowsUntrackedFiles`)
- [x] `--base` flag works (`TestDiffCustomBase`)
- [x] Unknown base returns error (`TestDiffUnknownBaseReturnsError`)

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gren diff` to show committed, staged, unstaged, and untracked changes relative to a base branch; accepts optional `--base` and auto-detects a sensible default when omitted.
* **Tests**
  * Added comprehensive tests covering committed, staged, unstaged, untracked scenarios, custom base handling, and unknown-base error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->