### PR TITLE
fix(create): skip navigate prompt when stdin is not a TTY

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -281,16 +281,22 @@ func (c *CLI) handleCreate(args []string) error {
 		// Print success output when not executing a command
 		output.WorktreeCreated(*name, branchName, worktreePath)
 
-		// Ask user if they want to navigate to the worktree
-		fmt.Print("\nNavigate to worktree? [Y/n]: ")
-		var response string
-		fmt.Scanln(&response)
-		response = strings.ToLower(strings.TrimSpace(response))
+		// Ask user if they want to navigate to the worktree, but only when
+		// stdin is a terminal. Non-interactive callers (CI, AI agents,
+		// scripts) would otherwise hang on Scanln waiting for input that
+		// never comes. Same pattern as the delete-confirmation guard
+		// further down in this file.
+		if term.IsTerminal(int(os.Stdin.Fd())) {
+			fmt.Print("\nNavigate to worktree? [Y/n]: ")
+			var response string
+			fmt.Scanln(&response)
+			response = strings.ToLower(strings.TrimSpace(response))
 
-		// Default is yes (empty, "y", or "yes")
-		if response == "" || response == "y" || response == "yes" {
-			if err := directive.WriteCD(worktreePath); err != nil {
-				logging.Error("Failed to set up navigation: %v", err)
+			// Default is yes (empty, "y", or "yes")
+			if response == "" || response == "y" || response == "yes" {
+				if err := directive.WriteCD(worktreePath); err != nil {
+					logging.Error("Failed to set up navigation: %v", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`gren create` would hang indefinitely on `Scanln` when stdin is piped or the caller is non-interactive (CI, AI agents, scripts). This guards the "Navigate to worktree?" prompt with `term.IsTerminal` so it's silently skipped in that case.

## Problem

`internal/cli/cli.go:285` reads stdin unconditionally:

```go
fmt.Print("\nNavigate to worktree? [Y/n]: ")
var response string
fmt.Scanln(&response)
```

When called like `echo "" | gren create -n X -y`, or from an AI agent's tool-call wrapper, this blocks until SIGTERM — the worktree IS created on disk, but the process never returns.

## Fix

Same pattern the `delete` command already uses further down in this file (line 529):

```go
if !term.IsTerminal(int(os.Stdin.Fd())) {
    return fmt.Errorf("...")
}
```

For `create` we silently skip the prompt (and the `cd`-directive) instead of erroring — the worktree is fine, the caller just won't be navigated. Interactive sessions are unaffected.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cli/...` passes (37s)
- [x] Manual: `echo "" | gren create -n test -y` returns in <1s with exit 0 (previously hung)
- [x] Manual: interactive `gren create -n test` still shows the prompt and navigates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the create command's interactive prompt to only appear when running in an interactive terminal, preventing hangs when used in scripts or non-interactive environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langtind/gren/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->