### PR TITLE
feat(hooks): add pre-create lifecycle hook

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -240,6 +240,23 @@ func (c *CLI) handleCreate(args []string) error {
 	}
 
 	ctx := context.Background()
+
+	// Run pre-create hook before any worktree state lands on disk.
+	// Fail-fast: a non-zero exit here aborts the create entirely so no
+	// half-built worktree is left behind for the caller to clean up.
+	// Branch name resolved early so the hook gets it in context.
+	preBranchName := *branch
+	if preBranchName == "" {
+		preBranchName = *name
+	}
+	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
+	preCreateResults := c.worktreeManager.RunPreCreateHookWithApproval(preBranchName, effectiveBaseBranch, *autoYes)
+	c.worktreeManager.SetEventObserver(nil)
+	printHookEvents(preCreateResults)
+	if core.HooksFailed(preCreateResults) {
+		return fmt.Errorf("pre-create hook failed; worktree not created")
+	}
+
 	worktreePath, warning, err := c.worktreeManager.CreateWorktree(ctx, req)
 	if err != nil {
 		logging.Error("CLI create failed: %v", err)

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -308,11 +308,12 @@ func showHooksHelp() {
 
 	fmt.Println(bold("AVAILABLE HOOKS"))
 	fmt.Println()
+	fmt.Println("  " + cyan("pre-create") + "    " + dim("Before creating a worktree (blocks on failure)"))
 	fmt.Println("  " + cyan("post-create") + "   " + dim("After creating a new worktree"))
 	fmt.Println("  " + cyan("post-switch") + "   " + dim("After switching to a worktree"))
 	fmt.Println("  " + cyan("pre-merge") + "     " + dim("Before merging (blocks on failure)"))
 	fmt.Println("  " + cyan("post-merge") + "    " + dim("After successful merge"))
-	fmt.Println("  " + cyan("pre-remove") + "    " + dim("Before deleting a worktree"))
+	fmt.Println("  " + cyan("pre-remove") + "    " + dim("Before deleting a worktree (blocks on failure)"))
 	fmt.Println("  " + cyan("post-start") + "    " + dim("After starting command with -x flag"))
 	fmt.Println()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ const (
 type HookType string
 
 const (
+	HookPreCreate  HookType = "pre-create"
 	HookPostCreate HookType = "post-create"
 	HookPreRemove  HookType = "pre-remove"
 	HookPostRemove HookType = "post-remove"
@@ -41,6 +42,10 @@ const (
 // Hooks represents the lifecycle hooks configuration.
 // Each hook can be either a simple command string or a path to a script.
 type Hooks struct {
+	// PreCreate runs before worktree creation (blocking, fail-fast).
+	// Non-zero exit aborts the create. Use for environment preflight
+	// checks (docker up, env files present, etc).
+	PreCreate string `json:"pre_create,omitempty" toml:"pre-create,omitempty"`
 	// PostCreate runs after worktree creation (blocking)
 	PostCreate string `json:"post_create,omitempty" toml:"post-create,omitempty"`
 	// PreRemove runs before worktree removal (blocking, fail-fast)
@@ -59,6 +64,7 @@ type Hooks struct {
 
 // ProjectNamedHooks holds named hooks for project configuration.
 type ProjectNamedHooks struct {
+	PreCreate  []NamedHook `toml:"pre-create,omitempty"`
 	PostCreate []NamedHook `toml:"post-create,omitempty"`
 	PreRemove  []NamedHook `toml:"pre-remove,omitempty"`
 	PostRemove []NamedHook `toml:"post-remove,omitempty"`
@@ -77,6 +83,8 @@ type CommitGenerator struct {
 // Get returns the hook command for the given hook type.
 func (h *Hooks) Get(hookType HookType) string {
 	switch hookType {
+	case HookPreCreate:
+		return h.PreCreate
 	case HookPostCreate:
 		return h.PostCreate
 	case HookPreRemove:
@@ -99,6 +107,8 @@ func (h *Hooks) Get(hookType HookType) string {
 // GetNamedHooks returns the named hooks for a given hook type.
 func (pnh *ProjectNamedHooks) GetNamedHooks(hookType HookType) []NamedHook {
 	switch hookType {
+	case HookPreCreate:
+		return pnh.PreCreate
 	case HookPostCreate:
 		return pnh.PostCreate
 	case HookPreRemove:
@@ -264,12 +274,13 @@ func (m *Manager) Save(config *Config) error {
 #
 # Available hooks (uncomment to use):
 # [hooks]
-# post-create = ".gren/post-create.sh"  # After creating worktree
-# post-switch = "npm run dev"            # After switching worktree
-# pre-merge = "npm test"                 # Before merging (blocks on failure)
-# post-merge = "echo 'Merged!'"          # After successful merge
-# pre-remove = "npm run cleanup"         # Before deleting worktree (blocks on failure)
-# post-remove = "echo 'Removed!'"        # After deleting worktree (best-effort, runs from repo root)
+# pre-create = "docker compose ps -q db"  # Before creating worktree (blocks on failure)
+# post-create = ".gren/post-create.sh"   # After creating worktree
+# post-switch = "npm run dev"             # After switching worktree
+# pre-merge = "npm test"                  # Before merging (blocks on failure)
+# post-merge = "echo 'Merged!'"           # After successful merge
+# pre-remove = "npm run cleanup"          # Before deleting worktree (blocks on failure)
+# post-remove = "echo 'Removed!'"         # After deleting worktree (best-effort, runs from repo root)
 #
 # For named hooks with branch filtering, see: gren help hooks
 

--- a/internal/core/hooks.go
+++ b/internal/core/hooks.go
@@ -160,8 +160,10 @@ func (wm *WorktreeManager) RunHooksWithApproval(hookType config.HookType, ctx Ho
 		result := wm.executeHook(hookType, hook.Command, ctx, hook.Name, hook.Interactive)
 		results = append(results, result)
 
-		// For fail-fast hooks (pre-remove, pre-merge), stop on first failure
-		if result.Err != nil && (hookType == config.HookPreRemove || hookType == config.HookPreMerge) {
+		// For fail-fast hooks (pre-create, pre-remove, pre-merge),
+		// stop on first failure — the caller treats Err on any of these
+		// as a signal to abort the lifecycle operation entirely.
+		if result.Err != nil && (hookType == config.HookPreCreate || hookType == config.HookPreRemove || hookType == config.HookPreMerge) {
 			break
 		}
 	}
@@ -618,6 +620,28 @@ func (wm *WorktreeManager) HasInteractiveHooks(hookType config.HookType) bool {
 	}
 
 	return false
+}
+
+// RunPreCreateHookWithApproval runs the pre-create hook with approval checking.
+// Returns the hook results. If autoYes is true, hooks are auto-approved.
+//
+// Pre-create runs BEFORE the worktree directory exists, so WorktreePath in
+// the context is the path that WILL be created — useful for environment
+// preflight (docker up, env vars present, etc) but the script can't `cd`
+// into it. Failure (Err != nil on any hook) aborts the create.
+func (wm *WorktreeManager) RunPreCreateHookWithApproval(branchName, baseBranch string, autoYes bool) []HookResult {
+	repoRoot, _ := wm.getRepoRoot()
+
+	ctx := HookContext{
+		// Pre-create has no worktree path yet — keep field set to repo root
+		// so scripts that do `cd "$1"` still land somewhere sensible.
+		WorktreePath: repoRoot,
+		BranchName:   branchName,
+		BaseBranch:   baseBranch,
+		RepoRoot:     repoRoot,
+	}
+
+	return wm.RunHooksWithApproval(config.HookPreCreate, ctx, autoYes)
 }
 
 // RunPostCreateHookWithApproval runs the post-create hook with approval checking.


### PR DESCRIPTION
## Summary

Add `pre-create` as a new hook lifecycle point that runs **before** the worktree directory is created. Non-zero exit aborts the create — fail-fast like `pre-remove` and `pre-merge` — so no half-built worktree is left behind for callers to clean up.

## Motivation

Currently every preflight check has to live in `post-create`, which means the worktree directory already exists on disk when the check fires. For setup steps that depend on infrastructure (docker stack reachable, secrets file present, migrations clean), failing in `post-create` leaves an orphan worktree the user has to manually rm + git worktree prune.

Real example from a downstream repo:
```toml
[hooks]
# Fail fast if docker isn't up — no point creating a worktree without it
pre-create = "make ensure-up"
post-create = ".gren/post-create.sh"
```

## Wired through all three layers

- **config** (`internal/config/config.go`): `HookPreCreate` type, `Hooks.PreCreate` field, `ProjectNamedHooks.PreCreate` entry, switch arms in `Hooks.Get` / `GetNamedHooks`, init-template example
- **core** (`internal/core/hooks.go`): `RunPreCreateHookWithApproval` exposed on `WorktreeManager`. The hook's `WorktreePath` context is the *prospective* path — useful for the script to know where the worktree *will* land, but the directory doesn't exist yet. Added `HookPreCreate` to the fail-fast set in `RunHooksWithApproval` (alongside the existing `HookPreRemove` / `HookPreMerge`)
- **cli** (`internal/cli/cli.go`): runs before `CreateWorktree`, returns error if any pre-create hook fails so the create aborts cleanly. Help text + init-template updated

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/config/... ./internal/core/... ./internal/cli/...` passes
- [x] E2E: `pre-create = "echo ok"` → worktree created, exit 0
- [x] E2E: `pre-create = "exit 1"` → no worktree, error message, event log captured

## Independent of other PRs

Doesn't depend on #38 or #39 — pre-create is a fresh code path. Merges cleanly on top of either.