### PR TITLE
chore(release): group release notes by conventional commit type

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,11 +43,36 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
+  # Pull commits + PR/author metadata from GitHub so release notes link
+  # back to the PR that introduced each change. Falls back to plain git
+  # log if the GitHub API isn't reachable from the runner.
+  use: github
   sort: asc
+  groups:
+    - title: "🚀 Features"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "🐛 Bugfixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "🧹 Refactoring"
+      regexp: '^.*?refactor(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: "📚 Docs"
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 3
+    - title: "🧪 Tests"
+      regexp: '^.*?test(\([[:word:]]+\))??!?:.+$'
+      order: 4
+    - title: "🏗️ Build / chore / CI"
+      regexp: '^.*?(build|chore|ci)(\([[:word:]]+\))??!?:.+$'
+      order: 5
+    - title: "Andre endringar"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+      - "^Merge pull request"
+      - "^Merge branch"
 
 brews:
   - repository:


### PR DESCRIPTION
## Summary

Goreleaser already builds release notes at tag time, but currently as a flat ascending list — readers can't tell at a glance what's a feature vs bugfix vs CI churn. Add `changelog.groups` so PRs are bucketed by their Conventional Commit prefix.

## Output shape (sample for next release)

Before this PR, release notes look like:

```
* fix(create): skip navigate prompt when stdin is not a TTY
* feat(create): add --format=json for machine-readable output
* feat(hooks): add pre-create lifecycle hook
* feat: live hook phase reporting in TUI + stderr capture
```

After this PR:

```
## 🚀 Features
* feat: live hook phase reporting in TUI + stderr capture
* feat(create): add --format=json for machine-readable output
* feat(hooks): add pre-create lifecycle hook

## 🐛 Bugfixes
* fix(create): skip navigate prompt when stdin is not a TTY
```

## What changed

- `use: github` — pulls commits + PR/author metadata from GitHub API so each entry links back to the PR and credits the author
- `groups` — six categories (Features / Bugfixes / Refactoring / Docs / Tests / Build·chore·CI) plus an "Andre endringar" catch-all for anything that doesn't match a Conventional Commit prefix
- `filters.exclude` — slimmed: dropped `^docs:` and `^test:` (those are categorised now), added `^Merge pull request` and `^Merge branch` to keep noise out

## Test plan

- [x] `goreleaser check` clean
- [x] `goreleaser release --snapshot --skip=publish --clean` succeeds — snapshot build of all 9 targets + homebrew formula + archives
- [ ] Live verification will be done on the v0.10.0 release that immediately follows this PR — if grouping doesn't render right we can hotfix the regex before the next tag

## Trade-off considered

Could have gone with `release-drafter` (kontinuerlig draft updated per PR-merge) instead — that's what flyt uses. Rejected because (a) gren is single-maintainer with low PR volume, (b) needs label-sync infrastructure that adds maintenance overhead, (c) goreleaser-changelog covers the same need without a new workflow.