### PR TITLE
fix(create): include pre-create hooks in --format=json output

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -267,8 +267,20 @@ func (c *CLI) handleCreate(args []string) error {
 	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
 	preCreateResults := c.worktreeManager.RunPreCreateHookWithApproval(preBranchName, effectiveBaseBranch, *autoYes)
 	c.worktreeManager.SetEventObserver(nil)
-	printHookEvents(preCreateResults)
+	if !jsonMode {
+		printHookEvents(preCreateResults)
+	}
 	if core.HooksFailed(preCreateResults) {
+		if jsonMode {
+			out := CreateJSON{
+				Name:   *name,
+				Branch: preBranchName,
+				Hooks:  hookResultsToJSON(preCreateResults),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(out)
+		}
 		return fmt.Errorf("pre-create hook failed; worktree not created")
 	}
 
@@ -305,11 +317,13 @@ func (c *CLI) handleCreate(args []string) error {
 	// prompt — callers (CI, AI agents) get a parseable result they can
 	// query for hook success/failure without scraping output.
 	if jsonMode {
+		allHooks := append([]core.HookResult{}, preCreateResults...)
+		allHooks = append(allHooks, postCreateResults...)
 		out := CreateJSON{
 			Name:   *name,
 			Branch: branchName,
 			Path:   worktreePath,
-			Hooks:  hookResultsToJSON(postCreateResults),
+			Hooks:  hookResultsToJSON(allHooks),
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -363,7 +377,7 @@ func (c *CLI) handleCreate(args []string) error {
 type CreateJSON struct {
 	Name   string     `json:"name"`
 	Branch string     `json:"branch"`
-	Path   string     `json:"path"`
+	Path   string     `json:"path,omitempty"`
 	Hooks  []HookJSON `json:"hooks,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- `gren create --format=json -y` was dropping pre-create hook results from the emitted JSON. PR #39 (`--format=json`) and PR #40 (pre-create lifecycle hook) were authored independently, and #40 didn't extend #39's emit path.
- Concatenate pre + post hook results in lifecycle order before serializing so machine-readable callers see every hook that ran.
- Emit a `CreateJSON` document on the pre-create failure path too — previously the command returned a bare error, leaving JSON consumers without the failing hook entry. The error return is preserved so the exit code stays non-zero.
- Suppress the human-readable pre-create phase summary in `--format=json` mode (matches existing post-create behavior); also mark `path` as `omitempty` so the failure document doesn't carry an empty path string.

## Test plan

- [x] `go build ./...`
- [x] `go test -p 1 ./...`
- [x] E2E success: `gren create -n test --format=json -y` with both `pre-create` and `post-create` hooks → JSON's `hooks[]` contains `pre-create-default` first, then `post-create-default`
- [x] E2E failure: `pre-create = "exit 1"` → exit non-zero, JSON document on stdout with the failing `pre-create-default` entry, no worktree directory created