### PR TITLE
feat(config): work on any git repo without gren init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`gren` now works without `gren init`.** A repository with no `.gren/config.toml` falls back to sensible defaults — worktrees under `../<repo>-worktrees`, package manager auto-detected, no hooks — instead of failing with `configuration not found: run 'gren init' first`. `config.Load()` now returns `DefaultRuntimeConfig()` when no config file exists; parse/validation errors on an *existing* file still surface as before. `gren init` remains for persisting customization (hooks, custom worktree dir). This matches how `git worktree` and worktrunk behave, so `gren create` (and tooling like the herdr plugin) works in any git repo.
+- Config load errors now name the offending file — e.g. `invalid configuration in .gren/config.toml: worktree_dir cannot be empty` and `failed to parse .gren/config.toml: ...` — instead of a generic "config file" message, so a malformed or mistyped config is faster to locate and fix.
+
+### Added (API)
+
+- `config.DefaultRuntimeConfig()` — the all-defaults configuration used for repositories without a `.gren` config file (empty `WorktreeDir` resolved to `../<repo>-worktrees` by consumers, `PackageManager` `auto`, no hooks).
+
 ## [0.10.0] — 2026-05-23
 
 ### Added

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -267,8 +267,20 @@ func (c *CLI) handleCreate(args []string) error {
 	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
 	preCreateResults := c.worktreeManager.RunPreCreateHookWithApproval(preBranchName, effectiveBaseBranch, *autoYes)
 	c.worktreeManager.SetEventObserver(nil)
-	printHookEvents(preCreateResults)
+	if !jsonMode {
+		printHookEvents(preCreateResults)
+	}
 	if core.HooksFailed(preCreateResults) {
+		if jsonMode {
+			out := CreateJSON{
+				Name:   *name,
+				Branch: preBranchName,
+				Hooks:  hookResultsToJSON(preCreateResults),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(out)
+		}
 		return fmt.Errorf("pre-create hook failed; worktree not created")
 	}
 
@@ -305,11 +317,13 @@ func (c *CLI) handleCreate(args []string) error {
 	// prompt — callers (CI, AI agents) get a parseable result they can
 	// query for hook success/failure without scraping output.
 	if jsonMode {
+		allHooks := append([]core.HookResult{}, preCreateResults...)
+		allHooks = append(allHooks, postCreateResults...)
 		out := CreateJSON{
 			Name:   *name,
 			Branch: branchName,
 			Path:   worktreePath,
-			Hooks:  hookResultsToJSON(postCreateResults),
+			Hooks:  hookResultsToJSON(allHooks),
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -363,7 +377,7 @@ func (c *CLI) handleCreate(args []string) error {
 type CreateJSON struct {
 	Name   string     `json:"name"`
 	Branch string     `json:"branch"`
-	Path   string     `json:"path"`
+	Path   string     `json:"path,omitempty"`
 	Hooks  []HookJSON `json:"hooks,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,21 +197,37 @@ func NewDefaultConfig(projectName, repoRoot string) (*Config, error) {
 	}, nil
 }
 
+// DefaultRuntimeConfig returns the configuration used when a repository has no
+// .gren config file. "Uninitialized" means "all defaults": no hooks, package
+// manager auto-detected, and an empty WorktreeDir that consumers resolve to
+// ../<repo>-worktrees at use time. This lets gren work on any git repository
+// without `gren init`; init only persists customization (hooks, custom paths).
+//
+// Unlike NewDefaultConfig, this does not point PostCreateHook at a hook script,
+// because an uninitialized repo has none — create simply runs no hooks.
+func DefaultRuntimeConfig() *Config {
+	return &Config{
+		WorktreeDir:    "", // empty → consumers default to ../<repo>-worktrees
+		PackageManager: "auto",
+		Version:        DefaultVersion,
+	}
+}
+
 // Load reads the configuration from the config file.
 // Tries TOML first (config.toml), then falls back to JSON (config.json).
 func (m *Manager) Load() (*Config, error) {
 	var config Config
 	var data []byte
 	var err error
-	var usedTOML bool
+	var usedPath string
 
 	// Try TOML first (preferred format)
 	tomlPath := filepath.Join(m.configDir, ConfigFileTOML)
 	data, err = os.ReadFile(tomlPath)
 	if err == nil {
-		usedTOML = true
+		usedPath = tomlPath
 		if err := toml.Unmarshal(data, &config); err != nil {
-			return nil, fmt.Errorf("failed to parse TOML config file: %w", err)
+			return nil, fmt.Errorf("failed to parse %s: %w", tomlPath, err)
 		}
 	} else if os.IsNotExist(err) {
 		// Fall back to JSON
@@ -219,26 +235,30 @@ func (m *Manager) Load() (*Config, error) {
 		data, err = os.ReadFile(jsonPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return nil, fmt.Errorf("configuration not found: run 'gren init' first")
+				// No config file: uninitialized repos use runtime defaults
+				// instead of erroring, so gren works on any git repo (like
+				// `git worktree`). `gren init` remains available to persist
+				// hooks and custom settings.
+				return DefaultRuntimeConfig(), nil
 			}
-			return nil, fmt.Errorf("failed to read config file: %w", err)
+			return nil, fmt.Errorf("failed to read %s: %w", jsonPath, err)
 		}
+		usedPath = jsonPath
 		if err := json.Unmarshal(data, &config); err != nil {
-			return nil, fmt.Errorf("failed to parse JSON config file: %w", err)
+			return nil, fmt.Errorf("failed to parse %s: %w", jsonPath, err)
 		}
 	} else {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
+		return nil, fmt.Errorf("failed to read %s: %w", tomlPath, err)
 	}
 
 	// Note: MainWorktree from old configs is ignored - now detected dynamically
-	_ = usedTOML // Can be used for logging/debugging
 
 	if config.PostCreateHook != "" && config.Hooks.PostCreate == "" {
 		config.Hooks.PostCreate = config.PostCreateHook
 	}
 
 	if err := m.validateConfig(&config); err != nil {
-		return nil, fmt.Errorf("invalid configuration: %w", err)
+		return nil, fmt.Errorf("invalid configuration in %s: %w", usedPath, err)
 	}
 
 	return &config, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -143,7 +144,7 @@ func TestManagerLoadSave(t *testing.T) {
 		}
 	})
 
-	t.Run("load missing config", func(t *testing.T) {
+	t.Run("load missing config returns defaults", func(t *testing.T) {
 		// Create a new temp dir without config
 		emptyDir, err := os.MkdirTemp("", "gren-empty-*")
 		if err != nil {
@@ -157,9 +158,12 @@ func TestManagerLoadSave(t *testing.T) {
 		defer os.Chdir(tempDir)
 
 		newManager := NewManager()
-		_, err = newManager.Load()
-		if err == nil {
-			t.Error("Load() expected error for missing config, got nil")
+		cfg, err := newManager.Load()
+		if err != nil {
+			t.Errorf("Load() missing config = error %v, want defaults with no error", err)
+		}
+		if cfg == nil || cfg.PackageManager != "auto" {
+			t.Errorf("Load() missing config = %+v, want default config", cfg)
 		}
 	})
 
@@ -227,6 +231,86 @@ func TestLoadInvalidJSON(t *testing.T) {
 	_, err = manager.Load()
 	if err == nil {
 		t.Error("Load() expected error for invalid JSON, got nil")
+	}
+}
+
+// TestLoadWithoutConfigReturnsDefaults verifies that a repo with no .gren config
+// loads sensible defaults instead of erroring, so gren works on any git repo
+// without `gren init` (init only persists customization).
+func TestLoadWithoutConfigReturnsDefaults(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "gren-noconfig-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+	os.Chdir(tempDir)
+
+	manager := NewManager()
+
+	cfg, err := manager.Load()
+	if err != nil {
+		t.Fatalf("Load() without config = error %v, want defaults with no error", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load() without config returned nil config")
+	}
+	if cfg.PackageManager != "auto" {
+		t.Errorf("PackageManager = %q, want %q", cfg.PackageManager, "auto")
+	}
+	if cfg.Version != DefaultVersion {
+		t.Errorf("Version = %q, want %q", cfg.Version, DefaultVersion)
+	}
+	// WorktreeDir is intentionally empty: consumers resolve it to ../<repo>-worktrees.
+	if cfg.WorktreeDir != "" {
+		t.Errorf("WorktreeDir = %q, want empty (resolved by consumers)", cfg.WorktreeDir)
+	}
+	// No hooks are configured by default.
+	if got := cfg.GetAllHooks(HookPostCreate); len(got) != 0 {
+		t.Errorf("GetAllHooks(post-create) = %d hooks, want 0", len(got))
+	}
+}
+
+// TestLoadErrorNamesConfigFile verifies that when an existing config file is
+// broken (unparseable or invalid), the error names the offending file so the
+// user knows what to fix — not a generic "config file" message.
+func TestLoadErrorNamesConfigFile(t *testing.T) {
+	wantPath := filepath.Join(ConfigDir, ConfigFileTOML)
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"malformed TOML", "worktree_dir = \"/x\ninvalid line"},
+		// Valid TOML but empty worktree_dir (e.g. a typo'd key) → validation error.
+		{"invalid config", "version = \"1.0.0\"\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "gren-errpath-*")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			originalDir, _ := os.Getwd()
+			defer os.Chdir(originalDir)
+			os.Chdir(tempDir)
+
+			os.MkdirAll(ConfigDir, 0755)
+			os.WriteFile(wantPath, []byte(tc.content), 0644)
+
+			_, err = NewManager().Load()
+			if err == nil {
+				t.Fatalf("Load() with %s = nil error, want error", tc.name)
+			}
+			if !strings.Contains(err.Error(), wantPath) {
+				t.Errorf("error %q does not name the config file %q", err, wantPath)
+			}
+		})
 	}
 }
 

--- a/internal/core/worktree_create_test.go
+++ b/internal/core/worktree_create_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,40 @@ func TestCreateWorktreeWithCustomDir(t *testing.T) {
 	})
 
 	_ = dir // keep reference for cleanup
+}
+
+// TestCreateWorktreeWithoutGrenInit verifies that gren create works on a git
+// repository that was never `gren init`-ed: it falls back to default settings
+// (no hooks) and places the worktree under the default ../<repo>-worktrees
+// directory instead of failing with "run 'gren init' first".
+func TestCreateWorktreeWithoutGrenInit(t *testing.T) {
+	dir, manager, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Simulate a repo that was never initialized by removing the config.
+	if err := os.RemoveAll(filepath.Join(dir, ".gren")); err != nil {
+		t.Fatalf("failed to remove .gren: %v", err)
+	}
+
+	worktreePath, _, err := manager.CreateWorktree(context.Background(), CreateWorktreeRequest{
+		Name:        "feature-x",
+		IsNewBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree() without gren init = error %v, want success", err)
+	}
+
+	// Resolve to an absolute path for cleanup while cwd is still the repo dir.
+	if absRoot, aerr := filepath.Abs(filepath.Dir(worktreePath)); aerr == nil {
+		defer os.RemoveAll(absRoot)
+	}
+
+	if !strings.Contains(worktreePath, "-worktrees") {
+		t.Errorf("worktree path = %q, want default ../<repo>-worktrees location", worktreePath)
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree not created at %q: %v", worktreePath, err)
+	}
 }
 
 func TestCreateWorktreeWithBaseBranch(t *testing.T) {


### PR DESCRIPTION
## What

`gren` now works on any git repository **without** `gren init`. When a repo has no `.gren/config.toml`, `config.Load()` returns `DefaultRuntimeConfig()` (worktrees under `../<repo>-worktrees`, package manager auto-detected, no hooks) instead of failing with `configuration not found: run 'gren init' first`.

`gren init` remains for **persisting customization** (hooks, custom worktree dir) — it's no longer a prerequisite for basic operation. This matches how `git worktree` and [worktrunk](https://github.com/max-sixty/worktrunk) behave, and lets tooling (e.g. a herdr plugin) create worktrees in any repo.

## Why

Requiring `gren init` before `gren create` is friction with no upside: the config is all sensible defaults except optional hooks. `git worktree` and worktrunk both work zero-config; gren now does too.

## Behavior contract (fail loud on corruption, default on absence)

- **No config file** → defaults, no error.
- **Malformed / invalid existing config** → still errors (unchanged). A typo'd key that leaves `worktree_dir` empty is caught rather than silently ignored.

Config load errors now **name the offending file**, e.g. `invalid configuration in .gren/config.toml: worktree_dir cannot be empty`.

## Tests (TDD, red→green verified)

- `TestLoadWithoutConfigReturnsDefaults` — missing config → defaults.
- `TestManagerLoadSave/load missing config` — updated from "expect error" to "expect defaults".
- `TestCreateWorktreeWithoutGrenInit` — end-to-end `CreateWorktree` on a repo with no `.gren`.
- `TestLoadErrorNamesConfigFile` — broken config errors name the file.

Existing `TestLoadInvalidTOML/JSON` still assert malformed configs error. Local: `gofmt`, `go vet`, `go test -p 1 ./...`, and `go test -p 1 -race ./...` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `gren` can now run in repositories without an existing config file by using sensible defaults.
  - JSON output for `gren create` now includes both pre-create and post-create hook results on success.

- **Bug Fixes**
  - Config and validation errors now point to the specific file that caused the problem.
  - JSON output no longer includes extra human-readable hook text when machine-readable mode is enabled.
  - Worktree creation now works in repos that haven’t been initialized yet, using the default worktree location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->