### PR TITLE
feat(create): add --no-hooks to create without running lifecycle hooks

### DIFF
--- a/.gren/post-create.sh
+++ b/.gren/post-create.sh
@@ -22,12 +22,10 @@ echo "🚀 Setting up new worktree..."
 # Copy development configuration files
 echo "📋 Copying gitignored development files..."
 
-# Read main repo path from config
-MAIN_REPO_PATH=$(grep -o '"main_repo_path"[^,}]*' .gren/config.json | cut -d':' -f2 | tr -d '" ')
-if [ -z "$MAIN_REPO_PATH" ]; then
-    echo "Warning: Could not read main_repo_path from config, using fallback"
-    MAIN_REPO_PATH="../"
-fi
+# gren passes the main repo root as the 4th argument ($4). (Older versions of
+# this hook grepped a "main_repo_path" key out of .gren/config.json, which no
+# longer exists — config is now .gren/config.toml and the root is passed in.)
+MAIN_REPO_PATH="${4:-..}"
 
 [ -d "$MAIN_REPO_PATH/.vscode/" ] && cp -r "$MAIN_REPO_PATH/.vscode/" . 2>/dev/null || true
 [ -d "$MAIN_REPO_PATH/.idea/" ] && cp -r "$MAIN_REPO_PATH/.idea/" . 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`gren create --no-hooks`** — create the worktree but skip the pre/post-create hooks, so a caller can run setup itself. This lets tooling (e.g. the herdr plugin) create at gren's configured `worktree_dir` and then run the post-create hook in a pane with a real TTY, so interactive setup (1Password `op`, `make seed`) works.
+
+### Fixed
+
+- The repo's own `.gren/post-create.sh` read `main_repo_path` from `.gren/config.json`, which no longer exists (config is `.gren/config.toml`, and gren passes the repo root to hooks as `$4`). It now uses `$4`. Dev tooling only; does not affect the gren binary.
+
 ## [0.11.0] — 2026-07-04
 
 ### Changed

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -164,6 +164,7 @@ func (c *CLI) handleCreate(args []string) error {
 	execute := fs.String("x", "", "Command to run after creating worktree (e.g., -x claude)")
 	autoYes := fs.Bool("y", false, "Auto-approve hooks without prompting")
 	format := fs.String("format", "", "Output format: json (machine-readable, suppresses prompts)")
+	noHooks := fs.Bool("no-hooks", false, "Create the worktree without running pre/post-create hooks")
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: gren create -n <name> [options]\n")
@@ -182,6 +183,7 @@ func (c *CLI) handleCreate(args []string) error {
 		fmt.Fprintf(fs.Output(), "  gren create -n feat-ui -x \"npm run dev\"   # Create and start dev server\n")
 		fmt.Fprintf(fs.Output(), "  gren create -n feat-api -y                # Auto-approve hooks\n")
 		fmt.Fprintf(fs.Output(), "  gren create -n feat-x --format=json -y    # Machine-readable, no prompts\n")
+		fmt.Fprintf(fs.Output(), "  gren create -n feat-x --no-hooks -y       # Create, skip hooks (run setup yourself)\n")
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -264,24 +266,27 @@ func (c *CLI) handleCreate(args []string) error {
 	if preBranchName == "" {
 		preBranchName = *name
 	}
-	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
-	preCreateResults := c.worktreeManager.RunPreCreateHookWithApproval(preBranchName, effectiveBaseBranch, *autoYes)
-	c.worktreeManager.SetEventObserver(nil)
-	if !jsonMode {
-		printHookEvents(preCreateResults)
-	}
-	if core.HooksFailed(preCreateResults) {
-		if jsonMode {
-			out := CreateJSON{
-				Name:   *name,
-				Branch: preBranchName,
-				Hooks:  hookResultsToJSON(preCreateResults),
-			}
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			_ = enc.Encode(out)
+	var preCreateResults []core.HookResult
+	if !*noHooks {
+		c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
+		preCreateResults = c.worktreeManager.RunPreCreateHookWithApproval(preBranchName, effectiveBaseBranch, *autoYes)
+		c.worktreeManager.SetEventObserver(nil)
+		if !jsonMode {
+			printHookEvents(preCreateResults)
 		}
-		return fmt.Errorf("pre-create hook failed; worktree not created")
+		if core.HooksFailed(preCreateResults) {
+			if jsonMode {
+				out := CreateJSON{
+					Name:   *name,
+					Branch: preBranchName,
+					Hooks:  hookResultsToJSON(preCreateResults),
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(out)
+			}
+			return fmt.Errorf("pre-create hook failed; worktree not created")
+		}
 	}
 
 	worktreePath, warning, err := c.worktreeManager.CreateWorktree(ctx, req)
@@ -302,14 +307,17 @@ func (c *CLI) handleCreate(args []string) error {
 	if branchName == "" {
 		branchName = *name
 	}
-	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
-	postCreateResults := c.worktreeManager.RunPostCreateHookWithApproval(worktreePath, branchName, effectiveBaseBranch, *autoYes)
-	c.worktreeManager.SetEventObserver(nil)
-	// In JSON mode the human-readable phase summary would corrupt stdout —
-	// hook results land in the JSON payload instead. Live stderr streaming
-	// above is still useful as a progress signal for log consumers.
-	if !jsonMode {
-		printHookEvents(postCreateResults)
+	var postCreateResults []core.HookResult
+	if !*noHooks {
+		c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
+		postCreateResults = c.worktreeManager.RunPostCreateHookWithApproval(worktreePath, branchName, effectiveBaseBranch, *autoYes)
+		c.worktreeManager.SetEventObserver(nil)
+		// In JSON mode the human-readable phase summary would corrupt stdout —
+		// hook results land in the JSON payload instead. Live stderr streaming
+		// above is still useful as a progress signal for log consumers.
+		if !jsonMode {
+			printHookEvents(postCreateResults)
+		}
 	}
 
 	// JSON mode: emit one machine-readable object on stdout and return.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -536,6 +536,37 @@ func TestHandleCreateSuccess(t *testing.T) {
 	_ = dir // worktree directory is based on config, success of create is sufficient
 }
 
+// TestHandleCreateNoHooksSkipsPostCreate verifies that `gren create --no-hooks`
+// creates the worktree but does not run the post-create hook — so a caller can
+// run setup itself (e.g. a herdr plugin running it in a pane with a TTY).
+func TestHandleCreateNoHooksSkipsPostCreate(t *testing.T) {
+	dir, cleanup := setupTempGitRepoWithCleanWorktrees(t)
+	defer cleanup()
+
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+	os.Chdir(dir)
+
+	projectName := filepath.Base(dir)
+	config.Initialize(projectName, true)
+
+	// Replace the generated hook with one that leaves a marker if it runs.
+	marker := filepath.Join(dir, "HOOK_RAN")
+	hook := "#!/usr/bin/env bash\ntouch '" + marker + "'\n"
+	if err := os.WriteFile(".gren/post-create.sh", []byte(hook), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	cli := NewCLI(git.NewLocalRepository(), config.NewManager())
+
+	if err := cli.ParseAndExecute([]string{"gren", "create", "-n", "nohooks-test", "--no-hooks", "-y"}); err != nil {
+		t.Fatalf("create --no-hooks failed: %v", err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("post-create hook ran despite --no-hooks")
+	}
+}
+
 func TestHandleCreateWithExistingBranch(t *testing.T) {
 	dir, cleanup := setupTempGitRepoWithCleanWorktrees(t)
 	defer cleanup()


### PR DESCRIPTION
## What

Adds `gren create --no-hooks`: create the worktree but skip the pre/post-create hooks.

## Why

A caller can then create at gren's configured `worktree_dir` and run the post-create hook **itself** — e.g. the herdr plugin runs it in a pane with a real TTY, so interactive setup (1Password `op` biometric, `make seed`) works. Without this, the picker's `gren create` runs hooks with captured stdio (no TTY), so `op` can't prompt; and the only TTY path (herdr's native create → event → pane) uses herdr's worktree location, not gren's. `--no-hooks` unifies it: gren's path **and** a TTY.

## Also

Fixes the repo's own `.gren/post-create.sh` — it grepped a `main_repo_path` key from `.gren/config.json` (gone; config is `.gren/config.toml`, and gren passes the repo root as `$4`). Dev tooling only, doesn't touch the binary.

## Tests

- `TestHandleCreateNoHooksSkipsPostCreate` (TDD, red→green): `--no-hooks` creates the worktree but the post-create hook does not run.
- Verified with the binary: `create --no-hooks --format=json` → worktree at gren's path, `hooks: []`, hook marker absent.
- Local: gofmt, `go vet`, `go test -p 1 ./...`, and `-race` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-hooks` option for creating a worktree without running pre-create or post-create hooks.
  * Updated help text and examples to show the new option.

* **Bug Fixes**
  * Post-create setup now gets the main repository path from the hook arguments instead of relying on removed config data.
  * Dev setup files and environment files continue to be copied into new worktrees as expected.

* **Tests**
  * Added coverage to confirm that `--no-hooks` skips the post-create hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->