### PR TITLE
fix: honor worktree_dir templates, named-hook branch globs, and user named hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`worktree_dir` templates now expand.** gren's config help advertises `worktree_dir = "../{{ repo }}-worktrees"`, but the value was used literally — you got a directory literally named `{{ repo }}`. It now runs through the template engine (`{{ repo }}`, `{{ branch }}`, `{{ branch | sanitize }}`).
+- **Named-hook `branches` globs are now honored.** `[[named-hooks.post-create]] branches = ["feature/*"]` was documented but never read, so the hook ran on every branch. Hooks are now filtered by their branch globs (`filepath.Match`).
+- **User-level named hooks now run.** Named hooks defined in the user config (`[[named-hooks.*]]`) were loaded but never merged into execution, so global hooks never fired. They now run for all repos, before project hooks.
+
+### Added (API)
+
+- `config.CollectHooks(project, user, hookType, branch)` and `config.BranchMatches(patterns, branch)` — assemble the hooks to run (user + project, branch-filtered, disabled-skipped) in one place.
+
 ## [0.12.0] — 2026-07-04
 
 ### Added

--- a/internal/config/collect_hooks.go
+++ b/internal/config/collect_hooks.go
@@ -1,0 +1,43 @@
+package config
+
+import "path/filepath"
+
+// BranchMatches reports whether branch is matched by a list of glob patterns.
+// An empty pattern list matches every branch (the hook is unconditional).
+func BranchMatches(patterns []string, branch string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, p := range patterns {
+		if ok, _ := filepath.Match(p, branch); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// CollectHooks returns the hooks to run for hookType on the given branch:
+// user-level named hooks first, then the project's hooks (simple + named),
+// filtered by each hook's optional branch globs and skipping disabled ones.
+// A nil user or project config is treated as empty.
+func CollectHooks(project *Config, user *UserConfig, hookType HookType, branch string) []NamedHook {
+	var all []NamedHook
+	if user != nil {
+		all = append(all, user.GetNamedHooks(hookType)...)
+	}
+	if project != nil {
+		all = append(all, project.GetAllHooks(hookType)...)
+	}
+
+	out := make([]NamedHook, 0, len(all))
+	for _, h := range all {
+		if h.Disabled {
+			continue
+		}
+		if !BranchMatches(h.Branches, branch) {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
+}

--- a/internal/config/collect_hooks_test.go
+++ b/internal/config/collect_hooks_test.go
@@ -1,0 +1,76 @@
+package config
+
+import "testing"
+
+func TestBranchMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		branch   string
+		want     bool
+	}{
+		{"empty patterns always match", nil, "anything", true},
+		{"exact match", []string{"main"}, "main", true},
+		{"glob match", []string{"feature/*"}, "feature/x", true},
+		{"glob no match", []string{"feature/*"}, "main", false},
+		{"one of several", []string{"main", "release/*"}, "release/1", true},
+		{"none match", []string{"feature/*"}, "fix/y", false},
+	}
+	for _, c := range cases {
+		if got := BranchMatches(c.patterns, c.branch); got != c.want {
+			t.Errorf("%s: BranchMatches(%v, %q) = %v, want %v", c.name, c.patterns, c.branch, got, c.want)
+		}
+	}
+}
+
+func cmds(hooks []NamedHook) []string {
+	out := make([]string, len(hooks))
+	for i, h := range hooks {
+		out[i] = h.Command
+	}
+	return out
+}
+
+func TestCollectHooks(t *testing.T) {
+	project := &Config{
+		Hooks: Hooks{PostCreate: "project-simple"},
+		NamedHooks: ProjectNamedHooks{
+			PostCreate: []NamedHook{
+				{Name: "feat-only", Command: "feat-cmd", Branches: []string{"feature/*"}},
+				{Name: "disabled", Command: "no", Disabled: true},
+			},
+		},
+	}
+	user := &UserConfig{
+		NamedHooks: NamedHooksConfig{
+			PostCreate: []NamedHook{{Name: "user-global", Command: "user-cmd"}},
+		},
+	}
+
+	t.Run("feature branch: user first, then project, disabled skipped", func(t *testing.T) {
+		got := CollectHooks(project, user, HookPostCreate, "feature/x")
+		want := []string{"user-cmd", "project-simple", "feat-cmd"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", cmds(got), want)
+		}
+		for i := range want {
+			if got[i].Command != want[i] {
+				t.Errorf("hook %d = %q, want %q (order %v)", i, got[i].Command, want[i], cmds(got))
+			}
+		}
+	})
+
+	t.Run("main: branch-filtered hook excluded", func(t *testing.T) {
+		got := CollectHooks(project, user, HookPostCreate, "main")
+		if want := []string{"user-cmd", "project-simple"}; len(got) != len(want) {
+			t.Fatalf("got %v, want %v", cmds(got), want)
+		}
+	})
+
+	t.Run("nil user config is fine", func(t *testing.T) {
+		got := CollectHooks(project, nil, HookPostCreate, "feature/x")
+		if len(got) != 2 { // project-simple + feat-cmd
+			t.Errorf("got %v, want 2 project hooks", cmds(got))
+		}
+	})
+}

--- a/internal/core/hooks.go
+++ b/internal/core/hooks.go
@@ -119,7 +119,11 @@ func (wm *WorktreeManager) RunHooksWithApproval(hookType config.HookType, ctx Ho
 		return nil
 	}
 
-	hooks := cfg.GetAllHooks(hookType)
+	// User-level named hooks (best-effort) run for all repos, before project
+	// hooks. CollectHooks also honors each hook's optional branch globs and
+	// skips disabled hooks — so branch-filtered and global hooks now work.
+	userCfg, _ := config.NewUserConfigManager().Load()
+	hooks := config.CollectHooks(cfg, userCfg, hookType, ctx.BranchName)
 	if len(hooks) == 0 {
 		logging.Debug("RunHooksWithApproval: no %s hooks configured", hookType)
 		return nil

--- a/internal/core/worktree.go
+++ b/internal/core/worktree.go
@@ -191,19 +191,33 @@ func (wm *WorktreeManager) CreateWorktree(ctx context.Context, req CreateWorktre
 	// Determine worktree path
 	worktreeDir := req.WorktreeDir
 	if worktreeDir == "" {
-		if cfg.WorktreeDir != "" {
-			worktreeDir = cfg.WorktreeDir
-			logging.Debug("Using worktree_dir from config: %s", worktreeDir)
-		} else {
-			// Default to ../repo-worktrees
-			repoInfo, err := wm.gitRepo.GetRepoInfo(ctx)
-			if err != nil {
-				logging.Error("Failed to get repo info: %v", err)
-				return "", "", fmt.Errorf("failed to get repo info: %w", err)
-			}
+		worktreeDir = cfg.WorktreeDir
+	}
+	// An empty dir needs the repo name for the default; a templated dir needs it
+	// to expand (e.g. worktree_dir = "../{{ repo }}-worktrees").
+	if worktreeDir == "" || strings.Contains(worktreeDir, "{{") {
+		repoInfo, err := wm.gitRepo.GetRepoInfo(ctx)
+		if err != nil {
+			logging.Error("Failed to get repo info: %v", err)
+			return "", "", fmt.Errorf("failed to get repo info: %w", err)
+		}
+		if worktreeDir == "" {
 			worktreeDir = fmt.Sprintf("../%s-worktrees", repoInfo.Name)
 			logging.Debug("Using default worktree_dir: %s", worktreeDir)
+		} else {
+			branchForTmpl := req.Branch
+			if branchForTmpl == "" {
+				branchForTmpl = req.Name
+			}
+			worktreeDir = expandTemplate(worktreeDir, TemplateContext{
+				Repo:            repoInfo.Name,
+				Branch:          branchForTmpl,
+				BranchSanitized: sanitizeBranch(branchForTmpl),
+			})
+			logging.Debug("Using worktree_dir from config (expanded): %s", worktreeDir)
 		}
+	} else {
+		logging.Debug("Using worktree_dir from config: %s", worktreeDir)
 	}
 
 	// Sanitize worktree name: replace / with - to avoid nested directories

--- a/internal/core/worktree_create_test.go
+++ b/internal/core/worktree_create_test.go
@@ -78,6 +78,38 @@ func TestCreateWorktreeWithoutGrenInit(t *testing.T) {
 	}
 }
 
+// TestCreateWorktreeExpandsWorktreeDirTemplate verifies that a templated
+// worktree_dir (which gren's own config help advertises, e.g.
+// "../{{ repo }}-worktrees") is expanded, not used literally.
+func TestCreateWorktreeExpandsWorktreeDirTemplate(t *testing.T) {
+	dir, manager, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	cfgToml := "worktree_dir = \"../{{ repo }}-tmplwt\"\npackage_manager = \"auto\"\nversion = \"1.0.0\"\n"
+	if err := os.WriteFile(".gren/config.toml", []byte(cfgToml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	worktreePath, _, err := manager.CreateWorktree(context.Background(), CreateWorktreeRequest{
+		Name:        "feat",
+		IsNewBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if absRoot, aerr := filepath.Abs(filepath.Dir(worktreePath)); aerr == nil {
+		defer os.RemoveAll(absRoot)
+	}
+
+	if strings.Contains(worktreePath, "{{") {
+		t.Errorf("worktree_dir template not expanded: %q", worktreePath)
+	}
+	if !strings.Contains(worktreePath, "-tmplwt") {
+		t.Errorf("expanded worktree path %q lost the template suffix", worktreePath)
+	}
+	_ = dir
+}
+
 func TestCreateWorktreeWithBaseBranch(t *testing.T) {
 	dir, manager, cleanup := setupTestEnvironment(t)
 	defer cleanup()


### PR DESCRIPTION
Three advertised-but-dead config features (surfaced comparing gren to worktrunk; each verified against source).

## Fixes

1. **`worktree_dir` templates were used literally.** The config help advertises `worktree_dir = "../{{ repo }}-worktrees"` (cli.go:2083/2121), but `worktree.go` joined the value verbatim → a directory literally named `{{ repo }}`. Now run through `expandTemplate`.
2. **Named-hook `branches` globs were never read** (`.Branches` had zero readers) → hooks ran on every branch. New `config.BranchMatches` filters them (`filepath.Match`).
3. **User-level named hooks were loaded but never merged** into execution → global `[[named-hooks.*]]` never fired. New `config.CollectHooks` merges user+project (user first), branch-filtered and disabled-skipped, wired into `RunHooksWithApproval`.

## Tests (TDD)

- `TestBranchMatches`, `TestCollectHooks` (user-first order, branch filter, disabled-skip, nil-safe).
- `TestCreateWorktreeExpandsWorktreeDirTemplate` (red→green).
- Verified with the built binary: `{{ repo }}` → repo name; `branches=["feature/*"]` runs on `feature/x`, skipped on `plain`; a user-level named hook runs in an arbitrary repo.
- gofmt, `go vet`, `go test -p 1 ./...`, `-race` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for branch-aware hook selection and expanded configuration options for organizing hooks.
  * Worktree locations can now be defined with templates and resolved dynamically.

* **Bug Fixes**
  * Fixed templates in worktree paths so they are expanded instead of treated as plain text.
  * Fixed branch filters so named hooks only run on matching branches.
  * Fixed user-level named hooks so they load correctly and run alongside project hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->