### PR TITLE
fix: resolve RepoRoot to the main worktree, not the current one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hooks run from inside a worktree now get the main repo as `RepoRoot`.** `getRepoRoot()` used `git rev-parse --show-toplevel`, which returns the *current* checkout — so when `gren hook-run` runs from a linked worktree (e.g. a herdr plugin's bootstrap pane), a hook's `$REPO_ROOT` (arg `$4`) and JSON `repo_root` pointed at the worktree instead of the main checkout. Hooks that reference shared, gitignored files there (symlinking a main-repo `.env`, reading shared config) silently no-op'd. It now resolves the main worktree via `git --git-common-dir`, so `RepoRoot`, `repo_root`, `{{ repo_root }}`, and relative `worktree_dir` are correct from any worktree. In a non-worktree repo the result is unchanged.
+
 ## [0.15.0] — 2026-07-04
 
 ### Added

--- a/internal/core/reporoot_test.go
+++ b/internal/core/reporoot_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// getRepoRoot must resolve to the MAIN worktree, not the current linked
+// worktree, so hook RepoRoot / repo_root / worktree_dir resolve against the
+// main checkout even when gren runs from inside a worktree — e.g. `gren
+// hook-run` invoked by the herdr plugin from the worktree's own pane. Without
+// this, a post-create hook's $REPO_ROOT points at the worktree and shared
+// files there (a gitignored .env in the main checkout) can't be found.
+func TestGetRepoRoot_FromLinkedWorktree(t *testing.T) {
+	main := mkRepo(t)
+	wt := filepath.Join(t.TempDir(), "feat-x")
+
+	add := exec.Command("git", "worktree", "add", "-b", "feat/x", wt)
+	add.Dir = main
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origWd)
+	if err := os.Chdir(wt); err != nil {
+		t.Fatal(err)
+	}
+
+	wm := &WorktreeManager{}
+	got, err := wm.getRepoRoot()
+	if err != nil {
+		t.Fatalf("getRepoRoot: %v", err)
+	}
+
+	wantReal, _ := filepath.EvalSymlinks(main)
+	gotReal, _ := filepath.EvalSymlinks(got)
+	if gotReal != wantReal {
+		t.Errorf("getRepoRoot from linked worktree = %q (real %q), want main repo %q (real %q)",
+			got, gotReal, main, wantReal)
+	}
+}

--- a/internal/core/worktree.go
+++ b/internal/core/worktree.go
@@ -1085,7 +1085,23 @@ func (wm *WorktreeManager) parseWorktreeList(output string) []WorktreeInfo {
 }
 
 func (wm *WorktreeManager) getRepoRoot() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	// Resolve the MAIN worktree's root, not the current linked worktree's
+	// toplevel. The main checkout is the parent of the shared git common dir,
+	// so this stays correct even when gren runs from inside a linked worktree
+	// (e.g. `gren hook-run` invoked by a plugin from the worktree's own pane) —
+	// hook RepoRoot / repo_root / worktree_dir then resolve against the main
+	// checkout, where shared gitignored files (a .env) live. In a non-worktree
+	// repo the common dir is <repo>/.git, so this equals --show-toplevel.
+	cmd := exec.Command("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if output, err := cmd.Output(); err == nil {
+		commonDir := strings.TrimSpace(string(output))
+		if commonDir != "" {
+			return filepath.Dir(filepath.Clean(commonDir)), nil
+		}
+	}
+
+	// Fallback for older git (< 2.31, no --path-format) or unexpected output.
+	cmd = exec.Command("git", "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get repository root: %w", err)


### PR DESCRIPTION
## Summary

`getRepoRoot()` used `git rev-parse --show-toplevel`, which returns the **current** checkout. When gren runs from inside a linked worktree — notably `gren hook-run` invoked by the gren-herdr plugin's bootstrap pane (cwd = the worktree) — a hook's `$REPO_ROOT` (`$4`) and the JSON `repo_root` pointed at the *worktree* instead of the *main* checkout.

Consequence: hooks that reference shared, gitignored files in the main checkout (symlinking the main-repo `.env`, reading shared config) **silently no-op'd** — the file path didn't exist under the worktree.

Fix: resolve the main worktree via `git rev-parse --path-format=absolute --git-common-dir` and take its parent. In a non-worktree repo the common dir is `<repo>/.git`, so the result equals `--show-toplevel` (no behavior change). Falls back to `--show-toplevel` for git < 2.31.

This also corrects `{{ repo_root }}` (`gren step eval` / `for-each`) and relative `worktree_dir` resolution when gren is invoked from a worktree.

## Discovery

Found while dogfooding the gren-herdr bootstrap rewire (0.15.0): a worktree's `.env` symlink from a post-create script hook never appeared. Traced to `RepoRoot` = the worktree; verified the symlink is created once `RepoRoot` resolves to the main repo.

## Testing

- TDD: `TestGetRepoRoot_FromLinkedWorktree` — creates a linked worktree, chdirs into it, asserts `getRepoRoot()` returns the main repo (was RED with the old `--show-toplevel`).
- `go test -p 1 ./...` green (no regressions); `go vet` + `gofmt` clean.
- Real binary: `gren hook-run --type post-create --path <worktree> --branch feat/login` run **from the worktree's cwd** now creates the main-repo `.env` symlink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hooks run from a linked worktree now correctly resolve the main repository root, so shared gitignored files are handled as expected.
  * Repository root detection now works more reliably in worktree setups, with fallback behavior preserved for older Git versions.

* **Tests**
  * Added coverage for repository root resolution when running from a linked worktree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->