### PR TITLE
fix: don't run config-migration prompt for CLI/tooling commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,11 +55,6 @@ func main() {
 	gitRepo := git.NewLocalRepository()
 	configManager := config.NewManager()
 
-	// Check for config migration (only if we're in an initialized project)
-	if configManager.Exists() {
-		checkAndPromptMigration(configManager)
-	}
-
 	// Check if we have CLI commands (anything beyond flags)
 	args := os.Args
 	cliArgs := []string{}
@@ -91,6 +86,15 @@ func main() {
 	}
 
 	// Default to TUI mode
+
+	// Offer config migration only here, right before the interactive TUI. The
+	// prompt writes to stdout and reads stdin, so running it for CLI/tooling
+	// commands (shell-init, completion, hook-run) would corrupt captured output —
+	// e.g. `eval "$(gren shell-init zsh)"` would eval the prompt text.
+	if configManager.Exists() {
+		checkAndPromptMigration(configManager)
+	}
+
 	// Create the model with dependencies
 	m := ui.NewModel(gitRepo, configManager, version)
 
@@ -153,6 +157,13 @@ func checkAndPromptMigration(configManager *config.Manager) {
 		if err != nil {
 			fmt.Printf("❌ Migration failed: %v\n", err)
 			logging.Error("Config migration failed: %v", err)
+			return
+		}
+		if migrationResult == nil {
+			// Nothing was migrated — e.g. a concurrent gren process already did
+			// it between our NeedsMigration check and Migrate(). Not an error;
+			// Migrate() returns (nil, nil) when there's nothing to do, so don't
+			// dereference it.
 			return
 		}
 


### PR DESCRIPTION
## Summary

`checkAndPromptMigration` ran in `main()` **before command dispatch**, so *every* gren invocation could trigger the interactive migration prompt — including `gren shell-init zsh`. Since shells run `eval "$(gren shell-init zsh)"`, the prompt text was captured and eval'd:

- `Config update available (v1.0.0 → v1.1.0)` → `(v…)` parsed as a glob qualifier → `zsh: unknown file attribute: v`
- `Update config? [Y/n]:` → `config?` parsed as a glob → `zsh: no matches found: config?`

It also **hung** (blocking on stdin during shell init) and, under a **concurrent** gren race (herdr fires several gren processes per worktree create), **panicked** with a nil-pointer deref in `checkAndPromptMigration` (`main.go:160`).

## Fix

- **Move** the migration prompt to run only immediately before the TUI, so no CLI/tooling command (`shell-init`, `completion`, `hook-run`, `create`) is interrupted or has its output corrupted.
- **Nil-check** `Migrate()`'s result: it returns `(nil, nil)` when there's nothing to migrate (e.g. another gren process migrated concurrently between our `NeedsMigration` check and `Migrate`); the caller dereferenced it → panic.

## Discovery + validation

Found dogfooding the herdr plugin: a worktree shell showed the `(eval)` errors + a `SIGSEGV` panic from `checkAndPromptMigration`. Reproduced locally with a PTY (`script -q /dev/null`) since the bug needs a TTY on stdin and/or concurrency — plain non-TTY `go test` misses it. Verified with a local build that `eval "$(gren shell-init zsh)"` and `gren hook-run` in an old-config repo are now clean (no prompt, no hang, no panic); `go test -p 1 ./...` green.