### PR TITLE
fix: stable GetProjectID across worktrees so hook approvals persist

### DIFF
--- a/internal/config/approval.go
+++ b/internal/config/approval.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // ApprovalManager handles persistent storage of approved hook commands.
@@ -164,20 +166,36 @@ func (am *ApprovalManager) ListApproved(projectID string) []string {
 	return commands
 }
 
-// GetProjectID returns a unique identifier for the current project.
+// GetProjectID returns a stable identifier for the whole project, shared by all
+// of its worktrees, so hook approvals persist across worktrees instead of being
+// re-prompted for each one.
+//
+// It prefers the git remote URL; failing that, the main worktree root (the
+// shared git common dir's parent, which is identical from every linked
+// worktree); and only as a last resort the current directory. The previous
+// implementation always used the current directory, so running from each
+// worktree produced a different ID and approvals never carried over.
 func GetProjectID() (string, error) {
-	// Use the git remote URL as a stable project identifier
-	// Fall back to the repository root path if no remote is configured
+	// 1. Git remote URL — stable across worktrees and machines.
+	if out, err := exec.Command("git", "remote", "get-url", "origin").Output(); err == nil {
+		if url := strings.TrimSpace(string(out)); url != "" {
+			return url, nil
+		}
+	}
+
+	// 2. Main worktree root (shared git common dir's parent). Identical from the
+	//    main checkout and every linked worktree, so approvals persist without a
+	//    remote.
+	if out, err := exec.Command("git", "rev-parse", "--path-format=absolute", "--git-common-dir").Output(); err == nil {
+		if commonDir := strings.TrimSpace(string(out)); commonDir != "" {
+			return filepath.Dir(filepath.Clean(commonDir)), nil
+		}
+	}
+
+	// 3. Last resort: the current directory (not a git repo).
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-
-	// Try to get the canonical path
-	absPath, err := filepath.Abs(cwd)
-	if err != nil {
-		absPath = cwd
-	}
-
-	return absPath, nil
+	return filepath.Clean(cwd), nil
 }

--- a/internal/config/approval_projectid_test.go
+++ b/internal/config/approval_projectid_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func gitProjectIDCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// GetProjectID must be stable across all worktrees of the same repo, so a hook
+// approved once (e.g. in a herdr bootstrap pane) isn't re-prompted for every new
+// worktree. The old implementation returned the current directory, so each
+// worktree produced a different ID and approvals never persisted.
+func TestGetProjectID_StableAcrossWorktrees(t *testing.T) {
+	main := t.TempDir()
+	gitProjectIDCmd(t, main, "init", "-b", "main")
+	gitProjectIDCmd(t, main, "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	gitProjectIDCmd(t, main, "worktree", "add", "-b", "feat/x", wt)
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig)
+
+	if err := os.Chdir(main); err != nil {
+		t.Fatal(err)
+	}
+	idMain, err := GetProjectID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(wt); err != nil {
+		t.Fatal(err)
+	}
+	idWt, err := GetProjectID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if idMain != idWt {
+		t.Errorf("project ID must be identical from the main checkout and a linked worktree so approvals persist; main=%q worktree=%q", idMain, idWt)
+	}
+}


### PR DESCRIPTION
## Summary

`GetProjectID()` returned `os.Getwd()` — despite its own comment promising the git remote URL with a repo-root fallback. The git-remote/repo-root logic was never implemented.

So when a hook runs from a **linked worktree** (the gren-herdr bootstrap pane runs `gren hook-run` with the worktree as cwd), the project ID was the *worktree path*. Every worktree has a different path → a different project ID → **hook approvals never persisted**: creating each new worktree re-prompted to approve the same `.gren/post-create.sh` commands.

## Fix

Resolve a stable identifier: git remote URL → else the main worktree root (`git --git-common-dir` parent, identical from the main checkout and every linked worktree) → else cwd. A hook approved once (`a`) now stays approved for all of the repo's worktrees.

## Testing

- TDD: `TestGetProjectID_StableAcrossWorktrees` — asserts the ID is identical from the main checkout and a linked worktree (RED with the old cwd-based impl).
- `go test -p 1 ./...` green.
- Validated end-to-end with a local build: approve in worktree A → creating worktree B (same repo) does not re-prompt and the hook runs.

## Discovery

Found dogfooding the herdr plugin: every new worktree re-asked to approve the post-create script even after choosing "always".