### PR TITLE
feat: capture interactive hook output to disk for post-mortem debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,11 +324,25 @@ go install github.com/langtind/gren@latest
 ### Log File Location
 - **macOS**: `~/Library/Logs/gren/gren.log`
 - **Linux**: `~/.local/state/gren/logs/gren.log`
+- Rotated at 5 MiB (`gren.log.1` .. `.3`). Override the directory with `GREN_LOG_DIR`
+  (tests set it to a temp dir so they don't pollute the real log).
 
-View recent logs:
+### `gren logs`
 ```bash
-tail -100 ~/Library/Logs/gren/gren.log  # macOS
+gren logs              # tail the last ~50 lines
+gren logs --path       # just the path (e.g. for $EDITOR "$(gren logs --path)")
+gren logs -f           # follow (tail -f)
+gren logs --last       # jump to the last error and its hook-output pointer
+gren logs --hooks      # list per-run hook output logs
 ```
+
+### Hook output capture
+Interactive hooks (`gren hook-run --interactive`, e.g. the herdr bootstrap pane)
+run against a real pty and their **combined output is tee'd to a per-run file** at
+`<logdir>/hooks/<type>-<branch>-<ts>.log`, with a pointer line in `gren.log`. This
+means a hook that fails in a pane that then closes still leaves a readable trace —
+`gren logs --last` points at the file. On SIGHUP/SIGTERM (pane teardown) or a panic,
+gren logs the cause before exiting instead of going silent.
 
 ## Dependencies
 

--- a/docs/superpowers/plans/2026-07-07-hook-logging-observability.md
+++ b/docs/superpowers/plans/2026-07-07-hook-logging-observability.md
@@ -1,0 +1,981 @@
+# Hook Logging & Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make gren hook failures diagnosable after the fact — even when a herdr pane closes or the process is killed — by capturing interactive hook output to disk, logging abnormal deaths, and adding a `gren logs` command.
+
+**Architecture:** Interactive hooks currently attach straight to the pane TTY, so their output is never captured (`internal/core/hooks.go:314-319`). We route interactive runs through a pseudo-terminal and tee the combined stream to both the terminal and a per-run disk file, keeping full TTY fidelity for `op`/`make seed`/`read`. A signal + panic handler records *how* gren died. A new `gren logs` command plus size-based rotation and a `GREN_LOG_DIR` override make the log reachable and clean.
+
+**Tech Stack:** Go, `github.com/creack/pty` (new, Unix-only), `golang.org/x/term` (existing), standard library.
+
+## Global Constraints
+
+- **Run tests with `-p 1`** (repo convention — tests use `os.Chdir`): `go test -p 1 ./...`.
+- **Design source of truth:** `docs/superpowers/specs/2026-07-07-hook-logging-observability-design.md`.
+- **New dependency limited to `github.com/creack/pty`**, Unix only; Windows keeps current behaviour via build tags.
+- **Per-run hook logs** live at `<logdir>/hooks/<hooktype>-<branch>-<unixnano>.log`; `<logdir>` = `getLogDir()`.
+- **Log rotation:** rotate `gren.log` at 5 MiB, keep 3 generations.
+- **Commits:** Conventional Commits, lowercase subject, signed (`git commit -S`). Never `--no-verify`.
+- **Branch:** all work on `feat/hook-logging-observability`.
+- **Interactive detection:** `interactive || wm.forceInteractive.Load()` (set by `--interactive`/`--tty`, `internal/cli/cli.go:2638`).
+
+---
+
+## File Structure
+
+- `internal/logging/logging.go` — add `GREN_LOG_DIR` override + `rotateIfLarge`; add `LogPanic`, `LogTermination`.
+- `internal/logging/hooklog.go` *(new)* — `HookLogDir`, `NewHookLog`, `PruneHookLogs`, `sanitizeLabel`.
+- `internal/core/hookpty_unix.go` *(new, `//go:build !windows`)* — `runInteractiveCaptured` via PTY.
+- `internal/core/hookpty_windows.go` *(new, `//go:build windows`)* — passthrough fallback.
+- `internal/core/hooks.go` — interactive branch tees to disk; `cappedWriter`; failure-log pointer.
+- `main.go` — signal handler + panic recovery.
+- `internal/cli/logs.go` *(new)* — `handleLogs` + pure helpers `tailLines`, `lastErrorBlock`, `followFile`, `listHookLogs`.
+- `internal/cli/cli.go` — dispatch `case "logs"`.
+- `internal/cli/help.go`, `internal/cli/completion.go` — surface the command.
+
+---
+
+## Task 1: Log-dir override + size rotation
+
+**Files:**
+- Modify: `internal/logging/logging.go` (`getLogDir`, `Init`)
+- Test: `internal/logging/logging_test.go`
+
+**Interfaces:**
+- Produces: `getLogDir()` honours `GREN_LOG_DIR`; `rotateIfLarge(path string, maxBytes int64, backups int)`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/logging/logging_test.go`:
+
+```go
+func TestGetLogDirHonorsEnvOverride(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", "/tmp/custom-gren-logs")
+	if got := getLogDir(); got != "/tmp/custom-gren-logs" {
+		t.Errorf("getLogDir() = %q, want /tmp/custom-gren-logs", got)
+	}
+}
+
+func TestRotateIfLargeRotatesWhenOverLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gren.log")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), 20), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rotateIfLarge(path, 10, 3) // 20 bytes > 10 → rotate
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be rotated away", path)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected %s.1 to exist: %v", path, err)
+	}
+}
+
+func TestRotateIfLargeKeepsSmallFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gren.log")
+	if err := os.WriteFile(path, []byte("small"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rotateIfLarge(path, 1024, 3)
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("small file should be left in place: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `go test -p 1 ./internal/logging/ -run 'TestGetLogDirHonorsEnvOverride|TestRotateIfLarge'`
+Expected: FAIL — `rotateIfLarge` undefined; override not honoured.
+
+- [ ] **Step 3: Implement**
+
+In `internal/logging/logging.go`, add the override as the first lines of `getLogDir`:
+
+```go
+func getLogDir() string {
+	if dir := os.Getenv("GREN_LOG_DIR"); dir != "" {
+		return dir
+	}
+	switch runtime.GOOS {
+	// ... existing cases unchanged ...
+	}
+}
+```
+
+Add near the top (after the `var (...)` block) the constants and rotation helper:
+
+```go
+const (
+	maxLogBytes = 5 * 1024 * 1024 // rotate gren.log past 5 MiB
+	logBackups  = 3               // keep gren.log.1 .. .3
+)
+
+// rotateIfLarge rotates path -> path.1 -> path.2 -> path.3 when it exceeds
+// maxBytes, keeping `backups` generations. Best-effort: on any error the
+// existing file is left in place and Init just appends to it.
+func rotateIfLarge(path string, maxBytes int64, backups int) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= maxBytes {
+		return
+	}
+	_ = os.Remove(fmt.Sprintf("%s.%d", path, backups))
+	for i := backups - 1; i >= 1; i-- {
+		_ = os.Rename(fmt.Sprintf("%s.%d", path, i), fmt.Sprintf("%s.%d", path, i+1))
+	}
+	_ = os.Rename(path, path+".1")
+}
+```
+
+In `Init`, call it right after computing `logPath`, before `os.OpenFile`:
+
+```go
+	logPath = filepath.Join(logDir, "gren.log")
+	rotateIfLarge(logPath, maxLogBytes, logBackups)
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test -p 1 ./internal/logging/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/logging/logging.go internal/logging/logging_test.go
+git commit -S -m "feat(logging): add GREN_LOG_DIR override and size-based rotation"
+```
+
+---
+
+## Task 2: Per-run hook log files
+
+**Files:**
+- Create: `internal/logging/hooklog.go`
+- Test: `internal/logging/hooklog_test.go`
+
+**Interfaces:**
+- Consumes: `getLogDir()` (Task 1).
+- Produces: `HookLogDir() string`; `NewHookLog(hookType, branch string) (*os.File, string, error)`; `PruneHookLogs(keepCount int, maxAge time.Duration)`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/logging/hooklog_test.go`:
+
+```go
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewHookLogCreatesFile(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
+	f, path, err := NewHookLog("post-create", "feat/x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("hello"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("hook log content = %q, want hello", data)
+	}
+	if !strings.Contains(filepath.Base(path), "post-create-feat-x-") {
+		t.Errorf("unexpected hook log name %q", filepath.Base(path))
+	}
+}
+
+func TestPruneHookLogsKeepsNewest(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
+	dir := HookLogDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("post-create-b-%d.log", i))
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Now().Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	PruneHookLogs(2, 24*time.Hour)
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 newest files kept, got %d", len(entries))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `go test -p 1 ./internal/logging/ -run 'HookLog'`
+Expected: FAIL — `NewHookLog`/`HookLogDir`/`PruneHookLogs` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/logging/hooklog.go`:
+
+```go
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HookLogDir is where per-run hook output logs live.
+func HookLogDir() string {
+	return filepath.Join(getLogDir(), "hooks")
+}
+
+// NewHookLog creates and opens a per-run hook output log, returning the open
+// file (caller closes it) and its path.
+func NewHookLog(hookType, branch string) (*os.File, string, error) {
+	dir := HookLogDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, "", fmt.Errorf("create hook log dir: %w", err)
+	}
+	name := fmt.Sprintf("%s-%s-%d.log", sanitizeLabel(hookType), sanitizeLabel(branch), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, path, nil
+}
+
+// PruneHookLogs keeps the newest keepCount hook logs and deletes any older than
+// maxAge. Best-effort; errors are ignored.
+func PruneHookLogs(keepCount int, maxAge time.Duration) {
+	entries, err := os.ReadDir(HookLogDir())
+	if err != nil {
+		return
+	}
+	type fileInfo struct {
+		path string
+		mod  time.Time
+	}
+	var files []fileInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, fileInfo{filepath.Join(HookLogDir(), e.Name()), info.ModTime()})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mod.After(files[j].mod) })
+	cutoff := time.Now().Add(-maxAge)
+	for i, f := range files {
+		if i >= keepCount || f.mod.Before(cutoff) {
+			_ = os.Remove(f.path)
+		}
+	}
+}
+
+// sanitizeLabel makes s safe as one filename segment.
+func sanitizeLabel(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test -p 1 ./internal/logging/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/logging/hooklog.go internal/logging/hooklog_test.go
+git commit -S -m "feat(logging): add per-run hook output log helpers"
+```
+
+---
+
+## Task 3: PTY tee capture for interactive hooks
+
+**Files:**
+- Create: `internal/core/hookpty_unix.go` (`//go:build !windows`)
+- Create: `internal/core/hookpty_windows.go` (`//go:build windows`)
+- Create: `internal/core/hookpty_unix_test.go` (`//go:build !windows`)
+- Create: `internal/core/hooks_capture_test.go`
+- Modify: `internal/core/hooks.go` (interactive branch ~313-325, failure log ~355; add `cappedWriter`, constants, `io` import)
+- Modify: `go.mod`, `go.sum` (add `github.com/creack/pty`)
+
+**Interfaces:**
+- Consumes: `logging.NewHookLog`, `logging.PruneHookLogs` (Task 2).
+- Produces: `runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error`; `cappedWriter{limit int}` with `Write` + `String()`.
+
+- [ ] **Step 1: Add the dependency**
+
+Run:
+```bash
+go get github.com/creack/pty@latest
+```
+Expected: `go.mod`/`go.sum` gain `github.com/creack/pty`.
+
+- [ ] **Step 2: Write failing tests**
+
+Create `internal/core/hooks_capture_test.go`:
+
+```go
+package core
+
+import "testing"
+
+func TestCappedWriterKeepsTail(t *testing.T) {
+	w := &cappedWriter{limit: 5}
+	if _, err := w.Write([]byte("abcdefgh")); err != nil {
+		t.Fatal(err)
+	}
+	if w.String() != "defgh" {
+		t.Errorf("cappedWriter tail = %q, want defgh", w.String())
+	}
+}
+```
+
+Create `internal/core/hookpty_unix_test.go`:
+
+```go
+//go:build !windows
+
+package core
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRunInteractiveCapturedTeesOutput(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo hello-stdout; echo hello-stderr >&2")
+	var out bytes.Buffer
+	if err := runInteractiveCaptured(cmd, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "hello-stdout") {
+		t.Errorf("captured output missing stdout: %q", got)
+	}
+	if !strings.Contains(got, "hello-stderr") {
+		t.Errorf("captured output missing stderr (pty merges streams): %q", got)
+	}
+}
+
+func TestRunInteractiveCapturedPropagatesExit(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 3")
+	var out bytes.Buffer
+	if err := runInteractiveCaptured(cmd, strings.NewReader(""), &out); err == nil {
+		t.Fatal("expected non-nil error for exit 3")
+	}
+}
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+Run: `go test -p 1 ./internal/core/ -run 'CappedWriter|RunInteractiveCaptured'`
+Expected: FAIL — `cappedWriter` and `runInteractiveCaptured` undefined.
+
+- [ ] **Step 4: Implement the PTY runner (Unix)**
+
+Create `internal/core/hookpty_unix.go`:
+
+```go
+//go:build !windows
+
+package core
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"os/exec"
+	"syscall"
+
+	"github.com/creack/pty"
+	"golang.org/x/term"
+)
+
+// runInteractiveCaptured runs cmd attached to a pseudo-terminal, copying stdin
+// into the pty and the pty output to out (typically a MultiWriter of the real
+// terminal and a disk sink). The child sees a real TTY, so interactive tools,
+// prompts, and colors behave exactly as with direct stdio. Returns cmd's exit
+// error. stdout and stderr are merged (a single pty), as a terminal shows them.
+func runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error {
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// Keep the pty sized to the controlling terminal.
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			_ = pty.InheritSize(os.Stdin, ptmx)
+		}
+	}()
+	ch <- syscall.SIGWINCH // initial resize
+	defer signal.Stop(ch)
+
+	// Put the outer terminal in raw mode so keystrokes pass through untouched;
+	// the pty's line discipline handles echo/cooking. Skip when stdin isn't a
+	// terminal (tests / non-tty callers).
+	if f, ok := stdin.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		if oldState, err := term.MakeRaw(int(f.Fd())); err == nil {
+			defer func() { _ = term.Restore(int(f.Fd()), oldState) }()
+		}
+	}
+
+	go func() { _, _ = io.Copy(ptmx, stdin) }()
+	_, _ = io.Copy(out, ptmx) // drains until the child closes the pty (EIO on Linux is expected)
+	return cmd.Wait()
+}
+```
+
+- [ ] **Step 5: Implement the Windows fallback**
+
+Create `internal/core/hookpty_windows.go`:
+
+```go
+//go:build windows
+
+package core
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// runInteractiveCaptured on Windows has no pty: run with direct stdio but tee
+// stdout/stderr into out on a best-effort basis. herdr is macOS/Linux; this
+// only keeps the Windows build green.
+func runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error {
+	cmd.Stdin = stdin
+	cmd.Stdout = io.MultiWriter(os.Stdout, out)
+	cmd.Stderr = io.MultiWriter(os.Stderr, out)
+	return cmd.Run()
+}
+```
+
+- [ ] **Step 6: Add `cappedWriter` to hooks.go**
+
+In `internal/core/hooks.go`, add `"io"` to the import block, and add near the top (after the imports):
+
+```go
+const (
+	hookTailLimit  = 64 * 1024        // bytes of hook output kept in memory for logs/UI
+	hookLogKeep    = 20               // per-run hook logs retained
+	hookLogMaxAge  = 7 * 24 * time.Hour
+)
+
+// cappedWriter keeps only the last `limit` bytes written — a bounded tail so
+// hook output can surface in logs/UI without unbounded memory.
+type cappedWriter struct {
+	buf   []byte
+	limit int
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.limit {
+		w.buf = w.buf[len(w.buf)-w.limit:]
+	}
+	return len(p), nil
+}
+
+func (w *cappedWriter) String() string { return string(w.buf) }
+```
+
+- [ ] **Step 7: Route the interactive branch through the tee**
+
+In `internal/core/hooks.go`, replace the interactive/non-interactive block (currently ~313-325) with:
+
+```go
+	var stdoutBuf, stderrBuf strings.Builder
+	var hookLogPath string
+	if interactive || wm.forceInteractive.Load() {
+		// Interactive: run against a real TTY (op / make seed / read all work),
+		// but tee the combined output to a per-run disk log and a capped tail so a
+		// failure leaves a trace even if the pane closes or gren is killed mid-run.
+		hookFile, path, logErr := logging.NewHookLog(string(hookType), ctx.BranchName)
+		if logErr != nil {
+			logging.Warn("could not open hook log, capture disabled: %v", logErr)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+		} else {
+			hookLogPath = path
+			tail := &cappedWriter{limit: hookTailLimit}
+			sink := io.MultiWriter(hookFile, tail)
+			err = runInteractiveCaptured(cmd, os.Stdin, io.MultiWriter(os.Stdout, sink))
+			_ = hookFile.Close()
+			stdoutBuf.WriteString(tail.String())
+			logging.Info("%s hook output → %s", hookType, path)
+			logging.PruneHookLogs(hookLogKeep, hookLogMaxAge)
+		}
+	} else {
+		cmd.Stdin = strings.NewReader(string(jsonData))
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		err = cmd.Run()
+	}
+```
+
+Then in the failure branch (currently ~355), add the pointer after the existing `logging.Error(...)`:
+
+```go
+	if err != nil {
+		logging.Error("%s hook failed: %v\nstdout: %s\nstderr: %s",
+			hookType, err, result.Output, result.Stderr)
+		if hookLogPath != "" {
+			logging.Error("%s hook full output → %s", hookType, hookLogPath)
+		}
+	} else {
+```
+
+- [ ] **Step 8: Run tests, verify pass**
+
+Run: `go test -p 1 ./internal/core/ -run 'CappedWriter|RunInteractiveCaptured'`
+Expected: PASS.
+Run: `go build ./...`
+Expected: builds clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go.mod go.sum internal/core/hookpty_unix.go internal/core/hookpty_windows.go \
+        internal/core/hookpty_unix_test.go internal/core/hooks_capture_test.go internal/core/hooks.go
+git commit -S -m "feat(core): capture interactive hook output to disk via a pty tee"
+```
+
+---
+
+## Task 4: Log abnormal termination (signals + panics)
+
+**Files:**
+- Modify: `internal/logging/logging.go` (add `LogPanic`, `LogTermination`)
+- Modify: `main.go` (signal handler + panic recovery)
+- Test: `internal/logging/logging_test.go`
+
+**Interfaces:**
+- Produces: `logging.LogPanic(recovered any, stack []byte)`; `logging.LogTermination(sig os.Signal)`.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/logging/logging_test.go`:
+
+```go
+func TestLogPanicWritesStackToDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFilePath := filepath.Join(tmpDir, "test.log")
+	file, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origLogger, origLogFile, origEnabled := logger, logFile, enabled
+	defer func() { logger, logFile, enabled = origLogger, origLogFile, origEnabled }()
+	logFile, logger, enabled = file, log.New(file, "", 0), true
+
+	LogPanic("boom", []byte("stackframe-xyz"))
+	file.Close()
+
+	data, err := os.ReadFile(logFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "panic: boom") || !strings.Contains(content, "stackframe-xyz") {
+		t.Errorf("log missing panic/stack, got: %s", content)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `go test -p 1 ./internal/logging/ -run TestLogPanicWritesStackToDisk`
+Expected: FAIL — `LogPanic` undefined.
+
+- [ ] **Step 3: Implement logging helpers**
+
+Add to `internal/logging/logging.go`:
+
+```go
+// LogPanic records a recovered panic (value + stack) to disk, best-effort.
+func LogPanic(recovered any, stack []byte) {
+	Error("panic: %v\n%s", recovered, stack)
+}
+
+// LogTermination records that the process is exiting because of a signal, then
+// closes the log so the line is flushed before the process goes away. Used from
+// a signal handler, since Go runs no deferred funcs on signal death.
+func LogTermination(sig os.Signal) {
+	Warn("terminating on signal: %v", sig)
+	Close()
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `go test -p 1 ./internal/logging/ -run TestLogPanicWritesStackToDisk`
+Expected: PASS.
+
+- [ ] **Step 5: Wire signal + panic handling into main**
+
+In `main.go`, add imports `os/signal`, `syscall`, `runtime/debug` (keep existing imports). Immediately after `defer logging.Close()` (currently line 31), insert:
+
+```go
+	// Record abnormal termination. On SIGHUP (pane/terminal closed) or SIGTERM
+	// (herdr killing the pane) Go runs no deferred funcs — without this the log
+	// goes silent exactly when a hook was mid-run.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		logging.LogTermination(s)
+		if sysSig, ok := s.(syscall.Signal); ok {
+			os.Exit(128 + int(sysSig))
+		}
+		os.Exit(1)
+	}()
+
+	// Record panics to disk before they hit stderr and the process dies.
+	defer func() {
+		if r := recover(); r != nil {
+			logging.LogPanic(r, debug.Stack())
+			logging.Close()
+			panic(r) // preserve original crash behaviour and exit code
+		}
+	}()
+```
+
+- [ ] **Step 6: Verify build + full logging tests**
+
+Run: `go build ./...`
+Expected: builds clean.
+Run: `go test -p 1 ./internal/logging/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/logging/logging.go internal/logging/logging_test.go main.go
+git commit -S -m "feat: log abnormal termination on signal or panic"
+```
+
+> **Manual E2E (not automated — note in PR):** in a herdr worktree, `prefix+shift+g` to create a worktree whose `post-create` hook fails, then `gren logs --last` should show the captured hook output; closing the pane mid-hook should leave a `terminating on signal: hangup` line. Build/swap the local binary per `docs/debugging.md` §1 before releasing.
+
+---
+
+## Task 5: `gren logs` command
+
+**Files:**
+- Create: `internal/cli/logs.go`
+- Create: `internal/cli/logs_test.go`
+- Modify: `internal/cli/cli.go` (add `case "logs"`)
+- Modify: `internal/cli/help.go`, `internal/cli/completion.go` (surface command)
+
+**Interfaces:**
+- Consumes: `logging.GetLogPath()`, `logging.HookLogDir()` (Tasks 1–2).
+- Produces: `handleLogs(args []string) error`; pure helpers `tailLines(s string, n int) []string`, `lastErrorBlock(s string) string`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/cli/logs_test.go`:
+
+```go
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTailLinesReturnsLastN(t *testing.T) {
+	got := tailLines("a\nb\nc\nd\n", 2)
+	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
+		t.Errorf("tailLines = %v, want [c d]", got)
+	}
+}
+
+func TestLastErrorBlockFindsLastWithContinuation(t *testing.T) {
+	logText := strings.Join([]string{
+		"[2026-07-07 10:00:00.000] [INFO] started",
+		"[2026-07-07 10:00:01.000] [ERROR] first fail",
+		"[2026-07-07 10:00:02.000] [INFO] ok",
+		"[2026-07-07 10:00:03.000] [ERROR] post-create hook failed: exit status 1",
+		"stdout: boom",
+		"more boom",
+	}, "\n")
+	got := lastErrorBlock(logText)
+	if !strings.Contains(got, "exit status 1") || !strings.Contains(got, "more boom") {
+		t.Errorf("lastErrorBlock missing last block/continuation: %q", got)
+	}
+	if strings.Contains(got, "first fail") {
+		t.Errorf("lastErrorBlock returned an earlier error too: %q", got)
+	}
+}
+
+func TestLastErrorBlockNoErrors(t *testing.T) {
+	if got := lastErrorBlock("[2026-07-07 10:00:00.000] [INFO] fine"); !strings.Contains(got, "no [ERROR]") {
+		t.Errorf("lastErrorBlock = %q, want no-error message", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `go test -p 1 ./internal/cli/ -run 'TailLines|LastErrorBlock'`
+Expected: FAIL — helpers undefined.
+
+- [ ] **Step 3: Implement the command + helpers**
+
+Create `internal/cli/logs.go`:
+
+```go
+package cli
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/langtind/gren/internal/logging"
+)
+
+// handleLogs implements `gren logs`.
+func (c *CLI) handleLogs(args []string) error {
+	fs := flag.NewFlagSet("logs", flag.ExitOnError)
+	pathOnly := fs.Bool("path", false, "Print only the log file path")
+	follow := fs.Bool("f", false, "Follow the log (like tail -f)")
+	fs.BoolVar(follow, "follow", false, "Follow the log (like tail -f)")
+	last := fs.Bool("last", false, "Print the last error block and its hook-output pointer")
+	fs.BoolVar(last, "errors", false, "Alias for --last")
+	hooks := fs.Bool("hooks", false, "List recent per-run hook output logs")
+	n := fs.Int("n", 50, "Number of trailing lines to print")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	path := logging.GetLogPath()
+	if path == "" {
+		return fmt.Errorf("logging not initialised; no log path")
+	}
+	if *pathOnly {
+		fmt.Println(path)
+		return nil
+	}
+	if *hooks {
+		return listHookLogs()
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read log: %w", err)
+	}
+	if *last {
+		fmt.Println(lastErrorBlock(string(content)))
+		return nil
+	}
+	for _, line := range tailLines(string(content), *n) {
+		fmt.Println(line)
+	}
+	if *follow {
+		return followFile(path)
+	}
+	return nil
+}
+
+// tailLines returns the last n lines of s, in order.
+func tailLines(s string, n int) []string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
+}
+
+// lastErrorBlock returns the last "[ERROR]" line plus any non-timestamped
+// continuation lines (captured stdout/stderr) that follow it, or a friendly
+// message if there are none. Timestamped lines start with "[20".
+func lastErrorBlock(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	idx := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(lines[i], "[ERROR]") {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return "no [ERROR] entries in log"
+	}
+	end := idx + 1
+	for end < len(lines) && !strings.HasPrefix(lines[end], "[20") {
+		end++
+	}
+	return strings.Join(lines[idx:end], "\n")
+}
+
+// followFile prints new lines appended to path until interrupted.
+func followFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			fmt.Print(line)
+			continue
+		}
+		if err != nil {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+}
+
+// listHookLogs prints the paths of recent per-run hook output logs.
+func listHookLogs() error {
+	dir := logging.HookLogDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fmt.Println("no hook logs yet")
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			fmt.Println(filepath.Join(dir, e.Name()))
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Wire dispatch**
+
+In `internal/cli/cli.go`, add to the `switch command` block (after `case "hook-run":`):
+
+```go
+	case "logs":
+		return c.handleLogs(args[2:])
+```
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `go test -p 1 ./internal/cli/ -run 'TailLines|LastErrorBlock'`
+Expected: PASS.
+Run: `go build -o /tmp/gren-dev . && /tmp/gren-dev logs --path`
+Expected: prints the log path (e.g. `~/Library/Logs/gren/gren.log`).
+
+- [ ] **Step 6: Surface in help + completion**
+
+In `internal/cli/help.go`, find the command list (grep for `shell-init`) and add a line modelled on the neighbours:
+
+```go
+	fmt.Println("  " + cyan("logs") + "            " + dim("Show gren's log (--path, -f, --last, --hooks)"))
+```
+
+In `internal/cli/completion.go`, add `logs` to the command word list in each of `bashCompletionScript`, `zshCompletionScript`, `fishCompletionScript` (grep for `hook-run` in each and add `logs` alongside it, matching the existing quoting/format).
+
+- [ ] **Step 7: Verify build**
+
+Run: `go build ./... && go test -p 1 ./internal/cli/`
+Expected: builds clean; tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/cli/logs.go internal/cli/logs_test.go internal/cli/cli.go \
+        internal/cli/help.go internal/cli/completion.go
+git commit -S -m "feat(cli): add gren logs command"
+```
+
+---
+
+## Task 6: Full verification + docs
+
+**Files:**
+- Modify: `internal/config`/`README`/`docs/debugging.md` as needed (documentation only)
+
+- [ ] **Step 1: Full test suite**
+
+Run: `go test -p 1 ./...`
+Expected: all PASS.
+
+- [ ] **Step 2: Document the log surface**
+
+Add a short "Logs" note to `internal/gren` skill docs / `README.md` (grep for the existing "Debugging"/"Log File Location" section in `CLAUDE.md` for tone): mention `gren logs`, per-run hook logs under `<logdir>/hooks/`, `GREN_LOG_DIR`, and rotation.
+
+- [ ] **Step 3: Real herdr validation (manual)**
+
+Per `docs/debugging.md` §1: `go build -o /tmp/gren-dev . && cp /tmp/gren-dev /opt/homebrew/bin/gren`. In herdr, `prefix+shift+g`, create a worktree with a deliberately failing `post-create` hook, confirm the pane's failure is now readable via `gren logs --last` and the pointer file. Restore the brew binary afterward.
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add -A
+git commit -S -m "docs: document gren logs and hook output capture"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Component 1 (PTY capture) → Tasks 2 + 3. ✅ per-run file, capped tail, Windows fallback, pointer line.
+- Component 2 (abnormal-death logging) → Task 4. ✅ signals + panic.
+- Component 3 (`gren logs` + rotation + `GREN_LOG_DIR` + retention) → Tasks 1, 2 (prune), 5. ✅
+- Non-goal (herdr pane teardown) → untouched. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. Completion-script edit (Task 5 Step 6) is guided by grep because the three scripts' exact quoting differs — the instruction names the anchor (`hook-run`) and the token to add (`logs`).
+
+**Type consistency:** `runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error` identical in unix/windows/tests. `cappedWriter{limit}` + `String()` consistent between hooks.go and its test. `NewHookLog`/`PruneHookLogs`/`HookLogDir` signatures match between definition (Task 2) and use (Task 3, Task 5). `LogPanic(any, []byte)` / `LogTermination(os.Signal)` match between definition and main.go use.

--- a/docs/superpowers/specs/2026-07-07-hook-logging-observability-design.md
+++ b/docs/superpowers/specs/2026-07-07-hook-logging-observability-design.md
@@ -1,0 +1,165 @@
+# Design: Hook logging & observability for herdr (and terminal) failures
+
+- **Date:** 2026-07-07
+- **Status:** Approved (pending spec review)
+- **Repo:** gren
+
+## Problem
+
+When gren runs a worktree hook inside a herdr pane and the hook fails, the pane
+often closes before the user can read what went wrong — and gren's on-disk log
+does **not** contain the answer either. Investigation of the real logs
+(`~/Library/Logs/gren/gren.log` + `~/.config/herdr/herdr-server.log`) established:
+
+1. **gren already logs to disk** on every path (`main.go:28` calls
+   `logging.Init()`), including CLI `hook-run`.
+2. **In non-interactive mode, hook stdout/stderr are captured and logged**
+   (`hooks.go:320-325`, `355-366`). The one recent non-interactive failure — a
+   `pre-remove` hook (2026-07-06 16:07) — was fully diagnosable from the log.
+3. **In interactive mode the output is NOT captured.** `--interactive`/`--tty`
+   sets `forceInteractive` (`cli.go:2638`, `worktree.go:32`), which routes hook
+   execution through `hooks.go:314-319`, wiring the child straight to the pane
+   TTY (`cmd.Stdout = os.Stdout`). `HookResult.Output`/`Stderr` stay empty, so a
+   failure logs `hook failed: exit status N` with **blank** output.
+4. The herdr integration hits **exactly** this path: `prefix+shift+g` →
+   `gren.open` (`~/.config/herdr/config.toml:25`) → plugin picker → bootstrap
+   pane → `gren hook-run --type post-create --interactive` (`bootstrap.sh:56`).
+5. **Signal death skips all logging.** herdr panes are torn down with SIGHUP /
+   SIGKILL (`herdr-server.log`: `signal=Hangup`, `signal=Kill`,
+   `PaneDied for unknown pane`). On a signal, Go runs no `defer`, so
+   `logging.Close()` and the failure log never fire → total silence. The
+   plugin's `read -rn1` "press any key to close" guard (`bootstrap.sh:60`) is
+   also killed with the pane, which is why the pane vanishes despite the guard.
+
+Net: the moment you most need the output — a hook failure in a pane that then
+closes — is precisely when the current log is blank. The recent successful
+runs confirm the gap benignly: they logged `post-create hook output:` followed
+by nothing.
+
+## Goals
+
+- Capture interactive hook output to disk **as it happens**, so a failure leaves
+  a readable trace even if the pane closes or the process is killed.
+- Record **how** gren died (signal / panic) instead of going silent.
+- Make the log easy to reach and read (`gren logs`), and stop it growing
+  unbounded / being polluted by test runs.
+- Preserve the interactive setup flow exactly — a real TTY for `op`, `make seed`,
+  `read` prompts, colors. No regression to what works today.
+
+## Non-goals
+
+- Fixing the herdr-side pane teardown (why the pane gets SIGHUP'd). That is a
+  herdr/plugin concern; this work makes it *diagnosable*, not fixed.
+- Per-worktree log correlation beyond the per-run hook file (no PID tagging of
+  every line in the main log).
+- Windows interactive capture (herdr is macOS/Linux; Windows keeps today's
+  direct passthrough).
+
+## Design
+
+Three components. All changes are in the **gren** Go project.
+
+### Component 1 — Capture interactive hook output via a PTY tee
+
+The child must run against a real TTY *and* gren must see the bytes. Chosen
+approach (decided): allocate a pseudo-terminal and tee its output.
+
+- Add dependency `github.com/creack/pty` (Unix; small, de-facto standard).
+- In `executeHook`, the interactive branch (`interactive || forceInteractive`)
+  becomes, on Unix:
+  - Open a **per-run hook log file** (Component 3 helper):
+    `<logdir>/hooks/<hooktype>-<branch-sanitized>-<unixnano>.log`.
+  - Build the output sink: `io.MultiWriter(hookFile, capBuf)` where `capBuf` is a
+    bounded (~64 KiB tail) in-memory buffer so `HookResult.Output` is non-empty
+    for the UI / failure log.
+  - Put the outer terminal (`os.Stdin`) into raw mode with `golang.org/x/term`
+    (already a dependency); `defer term.Restore`.
+  - `ptmx, err := pty.Start(cmd)` (sets the child's stdio to the pty slave).
+  - Set initial size + handle SIGWINCH via `pty.InheritSize(os.Stdin, ptmx)`.
+  - `go io.Copy(ptmx, os.Stdin)` (input); `io.Copy(io.MultiWriter(os.Stdout,
+    sink), ptmx)` (output, blocks to EOF); then `err = cmd.Wait()`.
+  - Close the hook file; write one pointer line to the main log:
+    `hook output → <path>`.
+- Result wiring: `result.Output = capBuf.String()`, `result.Stderr = ""`
+  (a single PTY merges stdout+stderr — expected and how a terminal shows it).
+  The existing failure log (`hooks.go:355`) now has real content + the pointer.
+- **Windows** (`//go:build windows`): keep today's direct `os.Stdout` passthrough
+  (no capture); log a debug note. Not a herdr target.
+- Non-interactive mode is unchanged (separate stdout/stderr string buffers).
+
+Rationale for a per-run file (not inline in `gren.log`): raw setup output (dozens
+of `make seed` lines, ANSI) would swamp the structured main log; a sibling file
+mirrors the existing `events` NDJSON pattern and is what `gren logs --last`
+points at.
+
+### Component 2 — Log abnormal termination
+
+- In `main.go`, install `signal.Notify(sigCh, SIGHUP, SIGTERM)` early. On signal:
+  `logging.Warn("terminating on signal: %v", s)`, `logging.Close()`,
+  `os.Exit(128 + signum)`. This makes pane teardown (SIGHUP) and herdr kill
+  (SIGTERM) leave a cause-of-death line + flush.
+- SIGINT is **not** globally trapped: during an interactive hook the outer
+  terminal is in raw mode, so Ctrl-C passes through the PTY to the child's line
+  discipline and interrupts the hook (unchanged behaviour).
+- Panic: a top-level `defer recover()` in `main()` logs `panic: <v>` + stack
+  (`runtime/debug.Stack()`) to disk, then re-panics (exit behaviour unchanged).
+  Limitation noted: cannot recover panics in other goroutines.
+- Because the log file is `O_APPEND` and unbuffered, every streamed line from
+  Component 1 is already on disk before death — so even a SIGKILL preserves the
+  partial output. Component 2 only adds the "why".
+
+### Component 3 — `gren logs` command + hygiene
+
+- **`gren logs`** (new CLI command, `internal/cli`):
+  - default: print the log path, then the last N (≈50) lines.
+  - `--path`: print only the path (for `$EDITOR "$(gren logs --path)"`).
+  - `-f` / `--follow`: native tail-follow (seek end, poll).
+  - `--last` / `--errors`: print the last `[ERROR]` block and, if the run has a
+    `hook output → <path>` pointer, the tail of that per-run hook file.
+  - `--hooks`: list recent per-run hook logs under `<logdir>/hooks/`.
+- **Rotation** in `logging.Init`: before opening, if `gren.log` > 5 MiB, rotate
+  `gren.log` → `.1` → `.2` → `.3` (keep 3), then open fresh. No new dependency.
+- **`GREN_LOG_DIR` override** in `getLogDir()`: if set, use it verbatim. The test
+  suite sets it to `t.TempDir()` so tests stop writing to the real user log
+  (today's 11:31 test burst is exactly this pollution). Documented for users too.
+- **Hook-log retention**: `PruneHookLogs()` keeps ~20 files / 7 days, mirroring
+  `events.Prune`; swept best-effort on each interactive hook spawn.
+
+## File-level changes
+
+- `internal/core/hooks.go` — interactive branch tees through PTY; failure log
+  uses captured tail + pointer.
+- `internal/core/hooks_pty_unix.go` / `hooks_pty_windows.go` — build-tagged PTY
+  runner vs. passthrough fallback.
+- `internal/logging/logging.go` — `GREN_LOG_DIR` override; size rotation;
+  `NewHookLog(hookType, branch)` + `HookLogDir()` + `PruneHookLogs()`.
+- `main.go` — signal handler (SIGHUP/SIGTERM) + panic recovery.
+- `internal/cli/cli.go` (+ `help.go`, `completion.go`) — `logs` command, flags,
+  help text, completions.
+- `go.mod` / `go.sum` — add `github.com/creack/pty`.
+
+## Testing
+
+Run with `-p 1` (repo convention — tests `os.Chdir`).
+
+- **logging**: rotation (write >5 MiB, assert rotated + fresh + backups kept);
+  `GREN_LOG_DIR` override honored; `NewHookLog` path + `PruneHookLogs` retention.
+- **PTY capture**: run `executeHook` interactively under a PTY (per
+  `docs/debugging.md` §2, `script`/creack-pty), assert the per-run hook file
+  contains the hook's echoed output and `HookResult.Output` is non-empty on
+  failure. This is the regression guard for the core gap.
+- **`gren logs`**: seed a temp log via `GREN_LOG_DIR`; assert `--path`, tail,
+  and `--last` (finds the seeded ERROR block).
+- **Signal/panic**: unit-test the panic-recovery writes a `panic:` line to disk.
+  Signal-kill (`SIGHUP` to a pty'd `hook-run`) is an optional/flaky E2E — mark
+  as such, don't gate CI on it.
+
+## Risks / notes
+
+- PTY merges stdout+stderr for interactive runs (documented; non-interactive
+  keeps them separate).
+- Raw-mode terminal must be restored on every exit path (`defer` + it's moot on
+  pane teardown since the pane is closing anyway).
+- `creack/pty` is Unix-only → build-tag fallback for Windows.
+- Validate the real herdr flow (build local, swap over the brew binary per
+  `docs/debugging.md` §1) before releasing — do not ship on unit tests alone.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/creack/pty v1.1.24
 	github.com/pelletier/go-toml/v2 v2.2.4
 	golang.org/x/term v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payR
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2157,11 +2157,12 @@ args = ["-p", "Write a conventional commit message for this diff. Output only th
 # branches = ["feature/*", "fix/*"]
 `
 
-// Example project configuration file content
-const projectConfigExample = `# gren project configuration
+// Example project configuration file content. The version is injected from
+// config.CurrentConfigVersion so the example never drifts behind the schema.
+var projectConfigExample = fmt.Sprintf(`# gren project configuration
 # See https://github.com/langtind/gren for documentation
 
-version = "1.0.0"
+version = "%s"
 
 # Worktree directory (absolute or relative to repository root)
 worktree_dir = "../{{ repo }}-worktrees"
@@ -2188,7 +2189,7 @@ post-create = ".gren/post-create.sh"
 # name = "install-deps"
 # command = "npm install"
 # branches = ["feature/*"]
-`
+`, config.CurrentConfigVersion)
 
 func (c *CLI) handleConfig(args []string) error {
 	if len(args) == 0 {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -138,6 +138,8 @@ func (c *CLI) ParseAndExecute(args []string) error {
 		return c.handleConfig(args[2:])
 	case "hook-run":
 		return c.handleHookRun(args[2:])
+	case "logs":
+		return c.handleLogs(args[2:])
 	case "install-skill":
 		return c.installSkillCmd(args[2:])
 	case "help":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2102,3 +2102,17 @@ func TestDiffUnknownBaseReturnsError(t *testing.T) {
 		t.Fatal("expected error for unknown base branch, got nil")
 	}
 }
+
+// TestProjectConfigExampleUsesCurrentVersion guards the `gren config create
+// --project` template against drifting behind the config schema. The version
+// is injected from config.CurrentConfigVersion, so this must always hold.
+func TestProjectConfigExampleUsesCurrentVersion(t *testing.T) {
+	want := fmt.Sprintf("version = %q", config.CurrentConfigVersion)
+	if !strings.Contains(projectConfigExample, want) {
+		t.Errorf("projectConfigExample missing %q; example config drifted from the schema version", want)
+	}
+	// Ensure no stale hardcoded version lingers (unless it happens to be current).
+	if config.CurrentConfigVersion != "1.0.0" && strings.Contains(projectConfigExample, `version = "1.0.0"`) {
+		t.Error("projectConfigExample still contains stale hardcoded version \"1.0.0\"")
+	}
+}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -107,7 +107,7 @@ func (c *CLI) handleCompletionQuery(args []string) error {
 			"navigate", "switch", "cd", "nav",
 			"compare", "merge", "for-each", "step",
 			"marker", "statusline", "shell-init", "completion",
-			"setup-claude-plugin",
+			"logs", "setup-claude-plugin",
 		}
 		for _, cmd := range commands {
 			fmt.Println(cmd)
@@ -124,7 +124,7 @@ _gren_completions() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="create list delete cleanup init navigate switch cd nav compare merge for-each step marker statusline shell-init completion setup-claude-plugin"
+    local commands="create list delete cleanup init navigate switch cd nav compare merge for-each step marker statusline shell-init completion logs setup-claude-plugin"
 
     case $cword in
         1)
@@ -241,6 +241,7 @@ _gren() {
         'statusline:Output status for shell prompts'
         'shell-init:Generate shell integration'
         'completion:Generate completion scripts'
+        'logs:Show gren log (--path, -f, --last, --hooks)'
         'setup-claude-plugin:Create Claude plugin hooks'
     )
 
@@ -380,6 +381,7 @@ complete -c gren -n '__fish_use_subcommand' -a marker -d 'Manage Claude activity
 complete -c gren -n '__fish_use_subcommand' -a statusline -d 'Output status for shell prompts'
 complete -c gren -n '__fish_use_subcommand' -a shell-init -d 'Generate shell integration'
 complete -c gren -n '__fish_use_subcommand' -a completion -d 'Generate completion scripts'
+complete -c gren -n '__fish_use_subcommand' -a logs -d 'Show gren log'
 complete -c gren -n '__fish_use_subcommand' -a setup-claude-plugin -d 'Create Claude plugin hooks'
 
 # Worktree completions for relevant commands

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -103,6 +103,7 @@ func (c *CLI) ShowColoredHelp() {
 	printCommand("init", "", "Initialize gren in repository")
 	printCommand("shell-init", "<shell>", "Generate shell integration")
 	printCommand("completion", "<shell>", "Generate shell completions")
+	printCommand("logs", "[--path|-f|--last]", "Show gren's log")
 	printCommand("help", "<topic>", "Show detailed help (e.g. hooks)")
 	fmt.Println()
 

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/langtind/gren/internal/logging"
+)
+
+// handleLogs implements `gren logs`.
+func (c *CLI) handleLogs(args []string) error {
+	fs := flag.NewFlagSet("logs", flag.ExitOnError)
+	pathOnly := fs.Bool("path", false, "Print only the log file path")
+	follow := fs.Bool("f", false, "Follow the log (like tail -f)")
+	fs.BoolVar(follow, "follow", false, "Follow the log (like tail -f)")
+	last := fs.Bool("last", false, "Print the last error block and its hook-output pointer")
+	fs.BoolVar(last, "errors", false, "Alias for --last")
+	hooks := fs.Bool("hooks", false, "List recent per-run hook output logs")
+	n := fs.Int("n", 50, "Number of trailing lines to print")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	path := logging.GetLogPath()
+	if path == "" {
+		return fmt.Errorf("logging not initialised; no log path")
+	}
+	if *pathOnly {
+		fmt.Println(path)
+		return nil
+	}
+	if *hooks {
+		return listHookLogs()
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read log: %w", err)
+	}
+	if *last {
+		fmt.Println(lastErrorBlock(string(content)))
+		return nil
+	}
+	for _, line := range tailLines(string(content), *n) {
+		fmt.Println(line)
+	}
+	if *follow {
+		return followFile(path)
+	}
+	return nil
+}
+
+// tailLines returns the last n lines of s, in order.
+func tailLines(s string, n int) []string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if n > 0 && len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
+}
+
+// lastErrorBlock returns the last "[ERROR]" line plus any non-timestamped
+// continuation lines (captured stdout/stderr) that follow it, or a friendly
+// message if there are none. Timestamped lines start with "[20".
+func lastErrorBlock(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	idx := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(lines[i], "[ERROR]") {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return "no [ERROR] entries in log"
+	}
+	end := idx + 1
+	for end < len(lines) && !strings.HasPrefix(lines[end], "[20") {
+		end++
+	}
+	return strings.Join(lines[idx:end], "\n")
+}
+
+// followFile prints new lines appended to path until interrupted.
+func followFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return err
+	}
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			fmt.Print(line)
+			continue
+		}
+		if err != nil {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+}
+
+// listHookLogs prints the paths of recent per-run hook output logs.
+func listHookLogs() error {
+	dir := logging.HookLogDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fmt.Println("no hook logs yet")
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			fmt.Println(filepath.Join(dir, e.Name()))
+		}
+	}
+	return nil
+}

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTailLinesReturnsLastN(t *testing.T) {
+	got := tailLines("a\nb\nc\nd\n", 2)
+	if len(got) != 2 || got[0] != "c" || got[1] != "d" {
+		t.Errorf("tailLines = %v, want [c d]", got)
+	}
+}
+
+func TestLastErrorBlockFindsLastWithContinuation(t *testing.T) {
+	logText := strings.Join([]string{
+		"[2026-07-07 10:00:00.000] [INFO] started",
+		"[2026-07-07 10:00:01.000] [ERROR] first fail",
+		"[2026-07-07 10:00:02.000] [INFO] ok",
+		"[2026-07-07 10:00:03.000] [ERROR] post-create hook failed: exit status 1",
+		"stdout: boom",
+		"more boom",
+	}, "\n")
+	got := lastErrorBlock(logText)
+	if !strings.Contains(got, "exit status 1") || !strings.Contains(got, "more boom") {
+		t.Errorf("lastErrorBlock missing last block/continuation: %q", got)
+	}
+	if strings.Contains(got, "first fail") {
+		t.Errorf("lastErrorBlock returned an earlier error too: %q", got)
+	}
+}
+
+func TestLastErrorBlockNoErrors(t *testing.T) {
+	if got := lastErrorBlock("[2026-07-07 10:00:00.000] [INFO] fine"); !strings.Contains(got, "no [ERROR]") {
+		t.Errorf("lastErrorBlock = %q, want no-error message", got)
+	}
+}

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/langtind/gren/internal/logging"
 )
 
 func TestTailLinesReturnsLastN(t *testing.T) {
@@ -33,5 +35,33 @@ func TestLastErrorBlockFindsLastWithContinuation(t *testing.T) {
 func TestLastErrorBlockNoErrors(t *testing.T) {
 	if got := lastErrorBlock("[2026-07-07 10:00:00.000] [INFO] fine"); !strings.Contains(got, "no [ERROR]") {
 		t.Errorf("lastErrorBlock = %q, want no-error message", got)
+	}
+}
+
+func TestHandleLogsPathLastHooks(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
+	if err := logging.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer logging.Close()
+	logging.Error("post-create hook failed: exit status 7")
+
+	c := &CLI{}
+	run := func(args ...string) string {
+		return captureStdout(t, func() {
+			if err := c.handleLogs(args); err != nil {
+				t.Errorf("handleLogs(%v): %v", args, err)
+			}
+		})
+	}
+
+	if pathOut := run("--path"); !strings.Contains(pathOut, "gren.log") {
+		t.Errorf("--path output = %q, want a gren.log path", pathOut)
+	}
+	if lastOut := run("--last"); !strings.Contains(lastOut, "exit status 7") {
+		t.Errorf("--last output = %q, want the seeded error", lastOut)
+	}
+	if hooksOut := run("--hooks"); !strings.Contains(hooksOut, "no hook logs") {
+		t.Errorf("--hooks output = %q, want the empty-state message", hooksOut)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,11 @@ const (
 	ConfigFileJSON = "config.json"
 	// ConfigFile is kept for backward compatibility, points to JSON.
 	ConfigFile = ConfigFileJSON
-	// DefaultVersion is the current configuration version.
-	DefaultVersion = "1.0.0"
+	// DefaultVersion is the version stamped into configs created by `gren init`.
+	// It is tied to CurrentConfigVersion (see migration.go) so a freshly written
+	// config is always at the current schema version and never triggers a
+	// migration nag. Bump CurrentConfigVersion, not this.
+	DefaultVersion = CurrentConfigVersion
 	// DefaultHookFile is the default post-create hook script.
 	DefaultHookFile = "post-create.sh"
 )

--- a/internal/config/migration_test.go
+++ b/internal/config/migration_test.go
@@ -78,6 +78,45 @@ func TestNeedsMigration_CurrentVersion(t *testing.T) {
 	}
 }
 
+// TestDefaultVersionMatchesCurrent guards against DefaultVersion (stamped into
+// configs at init time) drifting behind CurrentConfigVersion. If they diverge,
+// gren nags the user to migrate a config it just wrote itself.
+func TestDefaultVersionMatchesCurrent(t *testing.T) {
+	if DefaultVersion != CurrentConfigVersion {
+		t.Errorf("DefaultVersion = %q, but CurrentConfigVersion = %q; a freshly initialized config must be at the current schema version", DefaultVersion, CurrentConfigVersion)
+	}
+}
+
+// TestNewDefaultConfig_NoMigrationNeeded ensures a config freshly created by the
+// current binary does not immediately report needing migration. This is the
+// end-to-end symptom of the DefaultVersion/CurrentConfigVersion drift: `gren
+// init` writes a config that gren then flags as outdated.
+func TestNewDefaultConfig_NoMigrationNeeded(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".gren")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := &Manager{configDir: configDir}
+
+	config, err := NewDefaultConfig("test-project", tmpDir)
+	if err != nil {
+		t.Fatalf("NewDefaultConfig() error = %v", err)
+	}
+	if err := manager.Save(config); err != nil {
+		t.Fatal(err)
+	}
+
+	needsMigration, _, err := manager.NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration() error = %v", err)
+	}
+	if needsMigration {
+		t.Errorf("freshly created config (version %q) reports needing migration to %q; init must stamp the current schema version", config.Version, CurrentConfigVersion)
+	}
+}
+
 func TestNeedsMigration_OldVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, ".gren")

--- a/internal/core/hookpty_unix.go
+++ b/internal/core/hookpty_unix.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package core
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/creack/pty"
+	"golang.org/x/term"
+)
+
+// runInteractiveCaptured runs cmd attached to a pseudo-terminal, copying stdin
+// into the pty and the pty output to out (typically a MultiWriter of the real
+// terminal and a disk sink). The child sees a real TTY, so interactive tools,
+// prompts, and colors behave exactly as with direct stdio. Returns cmd's exit
+// error. stdout and stderr are merged (a single pty), as a terminal shows them.
+func runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error {
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// Keep the pty sized to the controlling terminal.
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			_ = pty.InheritSize(os.Stdin, ptmx)
+		}
+	}()
+	ch <- syscall.SIGWINCH // initial resize
+	defer signal.Stop(ch)
+
+	// Put the outer terminal in raw mode so keystrokes pass through untouched;
+	// the pty's line discipline handles echo/cooking. Skip when stdin isn't a
+	// terminal (tests / non-tty callers).
+	if f, ok := stdin.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		if oldState, err := term.MakeRaw(int(f.Fd())); err == nil {
+			defer func() { _ = term.Restore(int(f.Fd()), oldState) }()
+		}
+	}
+
+	go func() { _, _ = io.Copy(ptmx, stdin) }()
+	_, _ = io.Copy(out, ptmx) // drains until the child closes the pty (EIO on Linux is expected)
+	return cmd.Wait()
+}

--- a/internal/core/hookpty_unix_test.go
+++ b/internal/core/hookpty_unix_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package core
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRunInteractiveCapturedTeesOutput(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo hello-stdout; echo hello-stderr >&2")
+	var out bytes.Buffer
+	if err := runInteractiveCaptured(cmd, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "hello-stdout") {
+		t.Errorf("captured output missing stdout: %q", got)
+	}
+	if !strings.Contains(got, "hello-stderr") {
+		t.Errorf("captured output missing stderr (pty merges streams): %q", got)
+	}
+}
+
+func TestRunInteractiveCapturedPropagatesExit(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 3")
+	var out bytes.Buffer
+	if err := runInteractiveCaptured(cmd, strings.NewReader(""), &out); err == nil {
+		t.Fatal("expected non-nil error for exit 3")
+	}
+}

--- a/internal/core/hookpty_windows.go
+++ b/internal/core/hookpty_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package core
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// runInteractiveCaptured on Windows has no pty: run with direct stdio but tee
+// stdout/stderr into out on a best-effort basis. herdr is macOS/Linux; this
+// only keeps the Windows build green.
+func runInteractiveCaptured(cmd *exec.Cmd, stdin io.Reader, out io.Writer) error {
+	cmd.Stdin = stdin
+	cmd.Stdout = io.MultiWriter(os.Stdout, out)
+	cmd.Stderr = io.MultiWriter(os.Stderr, out)
+	return cmd.Run()
+}

--- a/internal/core/hooks.go
+++ b/internal/core/hooks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,29 @@ import (
 	"github.com/langtind/gren/internal/events"
 	"github.com/langtind/gren/internal/logging"
 )
+
+const (
+	hookTailLimit = 64 * 1024          // bytes of hook output kept in memory for logs/UI
+	hookLogKeep   = 20                 // per-run hook logs retained
+	hookLogMaxAge = 7 * 24 * time.Hour // per-run hook log max age
+)
+
+// cappedWriter keeps only the last `limit` bytes written — a bounded tail so
+// hook output can surface in logs/UI without unbounded memory.
+type cappedWriter struct {
+	buf   []byte
+	limit int
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.limit {
+		w.buf = w.buf[len(w.buf)-w.limit:]
+	}
+	return len(p), nil
+}
+
+func (w *cappedWriter) String() string { return string(w.buf) }
 
 // HookContext contains all information passed to hooks.
 type HookContext struct {
@@ -311,12 +335,28 @@ func (wm *WorktreeManager) executeHook(hookType config.HookType, hookCmd string,
 	// (stderr) — critical when a hook exits non-zero and we need to surface
 	// *where* it failed, not just that it failed.
 	var stdoutBuf, stderrBuf strings.Builder
+	var hookLogPath string
 	if interactive || wm.forceInteractive.Load() {
-		// Interactive mode: connect to terminal for user input
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
+		// Interactive: run against a real TTY (op / make seed / read all work),
+		// but tee the combined output to a per-run disk log and a capped tail so a
+		// failure leaves a trace even if the pane closes or gren is killed mid-run.
+		hookFile, path, logErr := logging.NewHookLog(string(hookType), ctx.BranchName)
+		if logErr != nil {
+			logging.Warn("could not open hook log, capture disabled: %v", logErr)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+		} else {
+			hookLogPath = path
+			tail := &cappedWriter{limit: hookTailLimit}
+			sink := io.MultiWriter(hookFile, tail)
+			err = runInteractiveCaptured(cmd, os.Stdin, io.MultiWriter(os.Stdout, sink))
+			_ = hookFile.Close()
+			stdoutBuf.WriteString(tail.String())
+			logging.Info("%s hook output → %s", hookType, path)
+			logging.PruneHookLogs(hookLogKeep, hookLogMaxAge)
+		}
 	} else {
 		cmd.Stdin = strings.NewReader(string(jsonData))
 		cmd.Stdout = &stdoutBuf
@@ -357,6 +397,9 @@ func (wm *WorktreeManager) executeHook(hookType config.HookType, hookCmd string,
 		// stderr, e.g. `bad substitution`) isn't lost in a merged blob.
 		logging.Error("%s hook failed: %v\nstdout: %s\nstderr: %s",
 			hookType, err, result.Output, result.Stderr)
+		if hookLogPath != "" {
+			logging.Error("%s hook full output → %s", hookType, hookLogPath)
+		}
 	} else {
 		logging.Info("%s hook completed successfully", hookType)
 		logging.Debug("%s hook output: %s", hookType, result.Output)

--- a/internal/core/hooks_capture_test.go
+++ b/internal/core/hooks_capture_test.go
@@ -1,0 +1,13 @@
+package core
+
+import "testing"
+
+func TestCappedWriterKeepsTail(t *testing.T) {
+	w := &cappedWriter{limit: 5}
+	if _, err := w.Write([]byte("abcdefgh")); err != nil {
+		t.Fatal(err)
+	}
+	if w.String() != "defgh" {
+		t.Errorf("cappedWriter tail = %q, want defgh", w.String())
+	}
+}

--- a/internal/core/hooks_interactive_test.go
+++ b/internal/core/hooks_interactive_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,13 +16,15 @@ import (
 // interactive setup like `op` TouchID or `make seed`.
 //
 // Observable contract: in captured (non-interactive) mode, executeHook records
-// the hook's stdout in result.Output; when stdio is inherited it goes straight
-// to the terminal, so result.Output is empty.
+// the hook's stdout in result.Output and stderr separately. In interactive mode
+// the hook runs against a real pty, but its combined output is tee'd to a capped
+// tail in result.Output (and a per-run disk log) so it is still captured.
 func TestExecuteHook_ForceInteractive(t *testing.T) {
 	repo := mkRepo(t)
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
 	t.Setenv("HOME", stateDir)
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
 
 	wm := &WorktreeManager{}
 	ctx := HookContext{WorktreePath: repo, BranchName: "main", RepoRoot: repo}
@@ -34,21 +38,65 @@ func TestExecuteHook_ForceInteractive(t *testing.T) {
 		t.Fatalf("expected captured stdout in non-interactive mode, got %q", base.Output)
 	}
 
-	// With force-interactive on, the same non-interactive hook inherits stdio,
-	// so nothing is captured into result.Output.
+	// Force-interactive runs against a real pty, but the combined output is now
+	// tee'd to a capped tail in Output — captured even though the child saw a TTY.
 	wm.SetForceInteractive(true)
-	forced := wm.executeHook(config.HookPostCreate, "true", ctx, "", false)
+	forced := wm.executeHook(config.HookPostCreate, "echo interactive-captured", ctx, "", false)
 	if forced.Err != nil {
 		t.Fatalf("forced hook failed: %v", forced.Err)
 	}
-	if forced.Output != "" {
-		t.Errorf("expected empty captured output when force-interactive, got %q", forced.Output)
+	if !strings.Contains(forced.Output, "interactive-captured") {
+		t.Errorf("expected interactive output tee'd to Output, got %q", forced.Output)
 	}
 
-	// Clearing it restores capture.
+	// Clearing it keeps normal capture.
 	wm.SetForceInteractive(false)
 	restored := wm.executeHook(config.HookPostCreate, "echo again", ctx, "", false)
 	if !strings.Contains(restored.Output, "again") {
-		t.Errorf("expected capture restored after clearing force-interactive, got %q", restored.Output)
+		t.Errorf("expected capture after clearing force-interactive, got %q", restored.Output)
+	}
+}
+
+// TestExecuteHook_InteractiveWritesHookLogFileOnFailure is the regression guard
+// for the core observability fix: an interactive hook that fails must leave its
+// full (merged stdout+stderr) output in a per-run disk file, so the trace
+// survives even if the pane closes on failure.
+func TestExecuteHook_InteractiveWritesHookLogFileOnFailure(t *testing.T) {
+	repo := mkRepo(t)
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("HOME", stateDir)
+	logDir := t.TempDir()
+	t.Setenv("GREN_LOG_DIR", logDir)
+
+	wm := &WorktreeManager{}
+	wm.SetForceInteractive(true)
+	ctx := HookContext{WorktreePath: repo, BranchName: "feat/x", RepoRoot: repo}
+
+	result := wm.executeHook(config.HookPostCreate,
+		"echo SETUP-BANNER; echo BOOM >&2; exit 1", ctx, "", false)
+
+	if result.Err == nil {
+		t.Fatal("expected the failing hook to return an error")
+	}
+	if !strings.Contains(result.Output, "SETUP-BANNER") {
+		t.Errorf("expected captured stdout in Output, got %q", result.Output)
+	}
+
+	hookDir := filepath.Join(logDir, "hooks")
+	entries, err := os.ReadDir(hookDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("expected a per-run hook log in %s (err=%v, entries=%d)", hookDir, err, len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(hookDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "SETUP-BANNER") || !strings.Contains(content, "BOOM") {
+		t.Errorf("hook log should hold both stdout and stderr (pty merges them), got: %q", content)
+	}
+	if !strings.Contains(entries[0].Name(), "post-create-feat-x-") {
+		t.Errorf("unexpected hook log name %q", entries[0].Name())
 	}
 }

--- a/internal/core/worktree.go
+++ b/internal/core/worktree.go
@@ -973,11 +973,18 @@ func (wm *WorktreeManager) DeleteWorktree(ctx context.Context, identifier string
 		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
+	// Callers pass a directory name, path, or branch (the CLI forwards the raw
+	// user argument; the merge flow passes the branch). Name/path matches win
+	// over a branch match so an exact name is never shadowed by another
+	// worktree's branch of the same spelling.
 	var targetWorktree *WorktreeInfo
 	for _, wt := range worktrees {
 		if wt.Name == identifier || wt.Path == identifier {
 			targetWorktree = &wt
 			break
+		}
+		if targetWorktree == nil && wt.Branch == identifier {
+			targetWorktree = &wt
 		}
 	}
 

--- a/internal/core/worktree_test.go
+++ b/internal/core/worktree_test.go
@@ -357,6 +357,32 @@ func TestDeleteWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("delete worktree by branch name", func(t *testing.T) {
+		// A slash in the name gives a dash-sanitized directory but keeps the
+		// slash in the branch — deleting by branch must still resolve it
+		// (the CLI and merge flow both pass the branch as identifier).
+		req := CreateWorktreeRequest{
+			Name:        "feat/delete-by-branch",
+			IsNewBranch: true,
+		}
+		_, _, err := manager.CreateWorktree(ctx, req)
+		if err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+
+		err = manager.DeleteWorktree(ctx, "feat/delete-by-branch", false)
+		if err != nil {
+			t.Fatalf("DeleteWorktree() by branch error: %v", err)
+		}
+
+		worktrees, _ := manager.ListWorktrees(ctx)
+		for _, wt := range worktrees {
+			if wt.Name == "feat-delete-by-branch" {
+				t.Error("worktree 'feat-delete-by-branch' still exists after deletion by branch")
+			}
+		}
+	})
+
 	t.Run("fail to delete current worktree", func(t *testing.T) {
 		worktrees, _ := manager.ListWorktrees(ctx)
 		var currentWorktree string

--- a/internal/logging/hooklog.go
+++ b/internal/logging/hooklog.go
@@ -1,0 +1,77 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HookLogDir is where per-run hook output logs live.
+func HookLogDir() string {
+	return filepath.Join(getLogDir(), "hooks")
+}
+
+// NewHookLog creates and opens a per-run hook output log, returning the open
+// file (caller closes it) and its path.
+func NewHookLog(hookType, branch string) (*os.File, string, error) {
+	dir := HookLogDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, "", fmt.Errorf("create hook log dir: %w", err)
+	}
+	name := fmt.Sprintf("%s-%s-%d.log", sanitizeLabel(hookType), sanitizeLabel(branch), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, path, nil
+}
+
+// PruneHookLogs keeps the newest keepCount hook logs and deletes any older than
+// maxAge. Best-effort; errors are ignored.
+func PruneHookLogs(keepCount int, maxAge time.Duration) {
+	entries, err := os.ReadDir(HookLogDir())
+	if err != nil {
+		return
+	}
+	type fileInfo struct {
+		path string
+		mod  time.Time
+	}
+	var files []fileInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, fileInfo{filepath.Join(HookLogDir(), e.Name()), info.ModTime()})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mod.After(files[j].mod) })
+	cutoff := time.Now().Add(-maxAge)
+	for i, f := range files {
+		if i >= keepCount || f.mod.Before(cutoff) {
+			_ = os.Remove(f.path)
+		}
+	}
+}
+
+// sanitizeLabel makes s safe as one filename segment.
+func sanitizeLabel(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+}

--- a/internal/logging/hooklog_test.go
+++ b/internal/logging/hooklog_test.go
@@ -1,0 +1,56 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewHookLogCreatesFile(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
+	f, path, err := NewHookLog("post-create", "feat/x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("hello"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("hook log content = %q, want hello", data)
+	}
+	if !strings.Contains(filepath.Base(path), "post-create-feat-x-") {
+		t.Errorf("unexpected hook log name %q", filepath.Base(path))
+	}
+}
+
+func TestPruneHookLogsKeepsNewest(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", t.TempDir())
+	dir := HookLogDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("post-create-b-%d.log", i))
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mt := time.Now().Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	PruneHookLogs(2, 24*time.Hour)
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 newest files kept, got %d", len(entries))
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -136,6 +136,19 @@ func Error(format string, args ...interface{}) {
 	}
 }
 
+// LogPanic records a recovered panic (value + stack) to disk, best-effort.
+func LogPanic(recovered any, stack []byte) {
+	Error("panic: %v\n%s", recovered, stack)
+}
+
+// LogTermination records that the process is exiting because of a signal, then
+// closes the log so the line is flushed before the process goes away. Used from
+// a signal handler, since Go runs no deferred funcs on signal death.
+func LogTermination(sig os.Signal) {
+	Warn("terminating on signal: %v", sig)
+	Close()
+}
+
 // SetOutput sets additional output (e.g., for debugging to stderr)
 func SetOutput(w io.Writer) {
 	if logger != nil {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -17,6 +17,26 @@ var (
 	enabled bool
 )
 
+const (
+	maxLogBytes = 5 * 1024 * 1024 // rotate gren.log past 5 MiB
+	logBackups  = 3               // keep gren.log.1 .. .3
+)
+
+// rotateIfLarge rotates path -> path.1 -> path.2 -> path.3 when it exceeds
+// maxBytes, keeping `backups` generations. Best-effort: on any error the
+// existing file is left in place and Init just appends to it.
+func rotateIfLarge(path string, maxBytes int64, backups int) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= maxBytes {
+		return
+	}
+	_ = os.Remove(fmt.Sprintf("%s.%d", path, backups))
+	for i := backups - 1; i >= 1; i-- {
+		_ = os.Rename(fmt.Sprintf("%s.%d", path, i), fmt.Sprintf("%s.%d", path, i+1))
+	}
+	_ = os.Rename(path, path+".1")
+}
+
 // Init initializes the logger with the default log path for the OS
 func Init() error {
 	logDir := getLogDir()
@@ -25,6 +45,7 @@ func Init() error {
 	}
 
 	logPath = filepath.Join(logDir, "gren.log")
+	rotateIfLarge(logPath, maxLogBytes, logBackups)
 
 	// Open log file in append mode
 	var err error
@@ -44,6 +65,9 @@ func Init() error {
 
 // getLogDir returns the appropriate log directory for the OS
 func getLogDir() string {
+	if dir := os.Getenv("GREN_LOG_DIR"); dir != "" {
+		return dir
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		// macOS: ~/Library/Logs/gren/

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -344,5 +345,28 @@ func TestLogPanicWritesStackToDisk(t *testing.T) {
 	content := string(data)
 	if !strings.Contains(content, "panic: boom") || !strings.Contains(content, "stackframe-xyz") {
 		t.Errorf("log missing panic/stack, got: %s", content)
+	}
+}
+
+func TestLogTerminationWritesSignalLine(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFilePath := filepath.Join(tmpDir, "test.log")
+	file, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origLogger, origLogFile, origEnabled := logger, logFile, enabled
+	defer func() { logger, logFile, enabled = origLogger, origLogFile, origEnabled }()
+	logFile, logger, enabled = file, log.New(file, "", 0), true
+
+	LogTermination(syscall.SIGHUP) // also closes the log file
+
+	data, err := os.ReadFile(logFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "terminating on signal: hangup") {
+		t.Errorf("log missing termination line, got: %s", data)
 	}
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -321,3 +321,28 @@ func TestRotateIfLargeKeepsSmallFile(t *testing.T) {
 		t.Errorf("small file should be left in place: %v", err)
 	}
 }
+
+func TestLogPanicWritesStackToDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFilePath := filepath.Join(tmpDir, "test.log")
+	file, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origLogger, origLogFile, origEnabled := logger, logFile, enabled
+	defer func() { logger, logFile, enabled = origLogger, origLogFile, origEnabled }()
+	logFile, logger, enabled = file, log.New(file, "", 0), true
+
+	LogPanic("boom", []byte("stackframe-xyz"))
+	file.Close()
+
+	data, err := os.ReadFile(logFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "panic: boom") || !strings.Contains(content, "stackframe-xyz") {
+		t.Errorf("log missing panic/stack, got: %s", content)
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -287,3 +287,37 @@ func TestCloseWithNilFile(t *testing.T) {
 	logFile = nil
 	Close() // Should not panic
 }
+
+func TestGetLogDirHonorsEnvOverride(t *testing.T) {
+	t.Setenv("GREN_LOG_DIR", "/tmp/custom-gren-logs")
+	if got := getLogDir(); got != "/tmp/custom-gren-logs" {
+		t.Errorf("getLogDir() = %q, want /tmp/custom-gren-logs", got)
+	}
+}
+
+func TestRotateIfLargeRotatesWhenOverLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gren.log")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), 20), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rotateIfLarge(path, 10, 3) // 20 bytes > 10 → rotate
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be rotated away", path)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected %s.1 to exist: %v", path, err)
+	}
+}
+
+func TestRotateIfLargeKeepsSmallFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gren.log")
+	if err := os.WriteFile(path, []byte("small"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rotateIfLarge(path, 1024, 3)
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("small file should be left in place: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"runtime/debug"
 	"strings"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/langtind/gren/internal/cli"
@@ -29,6 +32,29 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Warning: failed to initialize logging: %v\n", err)
 	}
 	defer logging.Close()
+
+	// Record abnormal termination. On SIGHUP (pane/terminal closed) or SIGTERM
+	// (herdr killing the pane) Go runs no deferred funcs — without this the log
+	// goes silent exactly when a hook was mid-run.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		logging.LogTermination(s)
+		if sysSig, ok := s.(syscall.Signal); ok {
+			os.Exit(128 + int(sysSig))
+		}
+		os.Exit(1)
+	}()
+
+	// Record panics to disk before they hit stderr and the process dies.
+	defer func() {
+		if r := recover(); r != nil {
+			logging.LogPanic(r, debug.Stack())
+			logging.Close()
+			panic(r) // preserve original crash behaviour and exit code
+		}
+	}()
 
 	// Set up embedded skill files for install-skill command
 	cli.SetSkillFS(skillFS, "skills/gren", "gren")


### PR DESCRIPTION
## Problem

When a gren hook fails inside a herdr pane, the pane often closes before the
output can be read — and gren's on-disk log doesn't contain the answer either.
Root cause: interactive hooks (`gren hook-run --interactive`, which the herdr
bootstrap pane uses) attach straight to the pane TTY, so their stdout/stderr are
**never captured** (`internal/core/hooks.go`). A failure logs `hook failed: exit
status N` with **empty** output. On top of that, when the pane is torn down with
SIGHUP/SIGTERM, Go runs no deferred funcs, so gren logs nothing at all — total
silence exactly when a hook was mid-run.

This was confirmed from real logs: recent interactive `post-create` runs logged
`post-create hook output:` followed by nothing.

## What changed

- **Capture interactive hook output to disk via a pty tee.** Interactive hooks
  now run against a real pseudo-terminal (so `op` / `make seed` / `read` and
  colors behave exactly as before), and the combined output is tee'd to both the
  terminal and a per-run file at `<logdir>/hooks/<type>-<branch>-<ts>.log`, plus
  a capped 64 KiB tail in `HookResult.Output`. A pointer line goes into
  `gren.log`. New dep: `github.com/creack/pty` (Unix; Windows keeps the current
  passthrough via build tags).
- **Log abnormal termination.** A SIGHUP/SIGTERM handler and a top-level panic
  recovery write the cause to disk (and flush) before the process dies.
- **`gren logs` command** — `--path`, `-f`/`--follow`, `--last` (jump to the last
  error + its hook-output pointer), `--hooks`.
- **Log hygiene** — `gren.log` rotates at 5 MiB (keep 3); `GREN_LOG_DIR` override
  (tests use it so they stop polluting the real user log).

Non-goal: fixing *why* herdr SIGHUPs the pane — that's a herdr/plugin concern.
This makes the failure diagnosable, not fixed.

Spec + plan: `docs/superpowers/specs/2026-07-07-hook-logging-observability-design.md`,
`docs/superpowers/plans/2026-07-07-hook-logging-observability.md`.

## Testing

- `go test -p 1 ./...` green.
- New coverage: `runInteractiveCaptured` 80%, `executeHook` interactive branch
  80%, `rotateIfLarge`/`LogPanic`/`LogTermination` 100%, `tailLines`/
  `lastErrorBlock` 100%, `handleLogs` 72%. `followFile` (infinite tail loop) is
  intentionally untested.
- Local end-to-end: a failing interactive `post-create` hook now leaves its full
  merged stdout+stderr in `<logdir>/hooks/*.log`, and `gren logs --last` points
  at it.

## Manual verification (do before releasing)

Per `docs/debugging.md` §1, build the local binary over the brew one and drive
the real herdr flow (`prefix+shift+g`), then confirm `gren logs --last` shows the
captured output of a failing `post-create` hook. Restore the official binary with
`brew reinstall gren && brew link --overwrite gren` afterward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `gren logs` command to view, tail, follow, and inspect recent log output.
  * Interactive hook runs now save per-run log files, making failures easier to review later.

* **Bug Fixes**
  * Improved logging for crashes and signal-based exits so unexpected terminations are recorded.
  * Freshly created project configs now use the current schema version, avoiding unnecessary migration warnings.
  * Worktrees can now be deleted using branch names more reliably, including names with slashes.

* **Chores**
  * Updated help and shell completion to include the new log command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->