### PR TITLE
feat(cli): gren logs --last prints the failed hook's output

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -44,6 +44,15 @@ func (c *CLI) handleLogs(args []string) error {
 		return fmt.Errorf("read log: %w", err)
 	}
 	if *last {
+		// Prefer the full captured output of the last failed hook — that's the
+		// actual cause, not just a pointer to a file. Fall back to the last error
+		// block for non-hook errors (e.g. a bad CLI invocation).
+		if p := lastFailedHookLogPath(string(content)); p != "" {
+			if data, readErr := os.ReadFile(p); readErr == nil {
+				fmt.Printf("Last hook failure — captured output (%s):\n\n%s", p, string(data))
+				return nil
+			}
+		}
 		fmt.Println(lastErrorBlock(string(content)))
 		return nil
 	}
@@ -63,6 +72,20 @@ func tailLines(s string, n int) []string {
 		lines = lines[len(lines)-n:]
 	}
 	return lines
+}
+
+// lastFailedHookLogPath returns the per-run hook log path from the most recent
+// "hook full output → <path>" line (logged only when a hook fails), or "" if
+// there is none.
+func lastFailedHookLogPath(s string) string {
+	const marker = "full output → "
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if idx := strings.Index(lines[i], marker); idx != -1 {
+			return strings.TrimSpace(lines[i][idx+len(marker):])
+		}
+	}
+	return ""
 }
 
 // lastErrorBlock returns the last "[ERROR]" line plus any non-timestamped

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -32,6 +32,20 @@ func TestLastErrorBlockFindsLastWithContinuation(t *testing.T) {
 	}
 }
 
+func TestLastFailedHookLogPath(t *testing.T) {
+	logText := strings.Join([]string{
+		"[2026-07-07 10:00:00.000] [INFO] started",
+		"[2026-07-07 10:00:01.000] [ERROR] post-create hook failed: exit status 1",
+		"[2026-07-07 10:00:01.000] [ERROR] post-create hook full output → /tmp/logs/hooks/post-create-x-123.log",
+	}, "\n")
+	if got := lastFailedHookLogPath(logText); got != "/tmp/logs/hooks/post-create-x-123.log" {
+		t.Errorf("lastFailedHookLogPath = %q, want the pointer path", got)
+	}
+	if got := lastFailedHookLogPath("[2026-07-07 10:00:00.000] [INFO] nothing failed"); got != "" {
+		t.Errorf("lastFailedHookLogPath = %q, want empty when no failure pointer", got)
+	}
+}
+
 func TestLastErrorBlockNoErrors(t *testing.T) {
 	if got := lastErrorBlock("[2026-07-07 10:00:00.000] [INFO] fine"); !strings.Contains(got, "no [ERROR]") {
 		t.Errorf("lastErrorBlock = %q, want no-error message", got)


### PR DESCRIPTION
Follow-up to #51. `gren logs --last` returned only the `full output → <path>` pointer line, forcing a second step to see the actual failure. Now it reads that per-run hook log and prints its contents, so the real cause (stderr trace, exit reason) is one command away. Falls back to the last error block for non-hook errors. New unit test `TestLastFailedHookLogPath`; `go test -p 1 ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `gren logs --last/--errors` now shows the full captured output from the most recent failed hook when available.
  * If the detailed hook output can’t be found or read, it falls back to the previous log summary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->