### PR TITLE
feat(delete): offer to force-remove worktrees git can't clean

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -629,6 +629,34 @@ func (c *CLI) handleList(args []string) error {
 }
 
 // handleDelete handles the delete command
+// worktreeBlockingContent returns the modified / untracked / ignored entries in
+// a worktree that make a plain `git worktree remove` fail (git output lines like
+// "!! node_modules/", "?? file", " M file"). Empty means a clean removal will
+// succeed.
+func worktreeBlockingContent(path string) []string {
+	out, err := exec.Command("git", "-C", path, "status", "--porcelain", "--ignored").Output()
+	if err != nil {
+		return nil
+	}
+	var lines []string
+	for _, l := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+	return lines
+}
+
+// capList returns at most n items, appending a "… and N more" line when the
+// input is longer, so a long leftover list doesn't flood the terminal.
+func capList(items []string, n int) []string {
+	if len(items) <= n {
+		return items
+	}
+	out := append([]string{}, items[:n]...)
+	return append(out, fmt.Sprintf("… and %d more", len(items)-n))
+}
+
 func (c *CLI) handleDelete(args []string) error {
 	fs := flag.NewFlagSet("delete", flag.ExitOnError)
 	force := fs.Bool("f", false, "Force deletion without confirmation")
@@ -714,7 +742,34 @@ func (c *CLI) handleDelete(args []string) error {
 
 	worktreePath := targetWorktree.Path
 	worktreeBranch := targetWorktree.Branch
-	err = c.worktreeManager.DeleteWorktree(ctx, worktreeName, *force)
+
+	// If a plain delete would fail because the checkout still holds files git
+	// won't remove on its own (leftover build output like node_modules/ or
+	// .venv/, or uncommitted files), list them and offer to force — rather than
+	// failing with a raw "Directory not empty".
+	effectiveForce := *force
+	if !effectiveForce {
+		if leftovers := worktreeBlockingContent(worktreePath); len(leftovers) > 0 {
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				return fmt.Errorf("worktree '%s' has content that blocks a clean delete; re-run with -f to force", worktreeName)
+			}
+			fmt.Printf("Worktree '%s' still contains files git won't remove on its own:\n", worktreeName)
+			for _, l := range capList(leftovers, 15) {
+				fmt.Printf("  %s\n", l)
+			}
+			fmt.Print("Force remove (this discards the above)? [y/N]: ")
+			var resp string
+			fmt.Scanln(&resp)
+			if r := strings.ToLower(strings.TrimSpace(resp)); r != "y" && r != "yes" {
+				logging.Info("CLI delete: user declined force removal of %s", worktreeName)
+				fmt.Println("Cancelled")
+				return nil
+			}
+			effectiveForce = true
+		}
+	}
+
+	err = c.worktreeManager.DeleteWorktree(ctx, worktreeName, effectiveForce)
 	if err != nil {
 		logging.Error("CLI delete failed: %v", err)
 		return err

--- a/internal/cli/delete_test.go
+++ b/internal/cli/delete_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorktreeBlockingContent(t *testing.T) {
+	dir := t.TempDir()
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "tracked.txt")
+	git("-c", "commit.gpgsign=false", "commit", "-m", "init")
+
+	if got := worktreeBlockingContent(dir); len(got) != 0 {
+		t.Errorf("clean worktree should have no blocking content, got %v", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "pkg"), []byte("y"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("z"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	joined := strings.Join(worktreeBlockingContent(dir), "\n")
+	if !strings.Contains(joined, "node_modules/") {
+		t.Errorf("blocking content should list ignored node_modules/, got %q", joined)
+	}
+	if !strings.Contains(joined, "untracked.txt") {
+		t.Errorf("blocking content should list untracked.txt, got %q", joined)
+	}
+}
+
+func TestCapList(t *testing.T) {
+	if got := capList([]string{"a", "b"}, 5); len(got) != 2 {
+		t.Errorf("capList within limit = %v, want unchanged", got)
+	}
+	got := capList([]string{"a", "b", "c", "d"}, 2)
+	if len(got) != 3 || got[2] != "… and 2 more" {
+		t.Errorf("capList over limit = %v, want [a b '… and 2 more']", got)
+	}
+}

--- a/internal/core/worktree.go
+++ b/internal/core/worktree.go
@@ -1010,11 +1010,12 @@ func (wm *WorktreeManager) DeleteWorktree(ctx context.Context, identifier string
 		}
 	}
 
-	// 2. Remove worktree using git
-	// Note: --force is required for worktrees with submodules (even after deinit)
-	// or when force parameter is true (to ignore uncommitted changes)
+	// 2. Remove worktree using git. --force is required for submodules (even
+	// after deinit) or when the caller forces (to ignore uncommitted/leftover
+	// content).
+	forceRemove := hasSubmodules || force
 	var cmd *exec.Cmd
-	if hasSubmodules || force {
+	if forceRemove {
 		cmd = exec.Command("git", "worktree", "remove", "--force", targetWorktree.Path)
 		if hasSubmodules {
 			logging.Debug("DeleteWorktree: using --force flag (worktree has submodules)")
@@ -1027,6 +1028,25 @@ func (wm *WorktreeManager) DeleteWorktree(ctx context.Context, identifier string
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		outputStr := string(output)
+		// When force was requested, complete the removal even if git still
+		// refuses — e.g. leftover ignored content ("Directory not empty") or a
+		// worktree left half-removed by a prior non-force attempt. Remove the
+		// checkout directly and prune the now-stale registration.
+		if forceRemove {
+			logging.Warn("DeleteWorktree: 'git worktree remove --force' failed (%s); removing directory and pruning", strings.TrimSpace(outputStr))
+			if rmErr := os.RemoveAll(targetWorktree.Path); rmErr != nil {
+				return fmt.Errorf("failed to remove worktree '%s' directory: %w", targetWorktree.Name, rmErr)
+			}
+			pruneCmd := exec.Command("git", "worktree", "prune")
+			if repoRoot, rrErr := wm.getRepoRoot(); rrErr == nil {
+				pruneCmd.Dir = repoRoot
+			}
+			if pruneOut, pruneErr := pruneCmd.CombinedOutput(); pruneErr != nil {
+				logging.Warn("DeleteWorktree: 'git worktree prune' failed: %v (%s)", pruneErr, strings.TrimSpace(string(pruneOut)))
+			}
+			logging.Info("Deleted worktree '%s' via force fallback (branch '%s' is preserved)", targetWorktree.Name, targetWorktree.Branch)
+			return nil
+		}
 		var hint string
 		if strings.Contains(outputStr, "submodules") {
 			hint = "The worktree contains submodules. Try running:\n  git -C " + targetWorktree.Path + " submodule deinit --all --force\nThen try deleting again with force."

--- a/internal/core/worktree_delete_test.go
+++ b/internal/core/worktree_delete_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDeleteWorktreeForceRemovesLeftoverContent guards that a forced delete
+// completes even when the checkout still holds gitignored content (e.g.
+// node_modules/ or .venv/) that a plain `git worktree remove` refuses to delete
+// with "Directory not empty".
+func TestDeleteWorktreeForceRemovesLeftoverContent(t *testing.T) {
+	_, manager, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, _, err := manager.CreateWorktree(ctx, CreateWorktreeRequest{Name: "leftover-test", IsNewBranch: true}); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+
+	var wtPath string
+	wts, _ := manager.ListWorktrees(ctx)
+	for _, wt := range wts {
+		if wt.Name == "leftover-test" {
+			wtPath = wt.Path
+			break
+		}
+	}
+	if wtPath == "" {
+		t.Fatal("could not find the created worktree")
+	}
+
+	// Gitignored leftover content a plain `git worktree remove` won't delete.
+	if err := os.WriteFile(filepath.Join(wtPath, ".gitignore"), []byte("node_modules/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wtPath, "node_modules"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "node_modules", "pkg"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.DeleteWorktree(ctx, "leftover-test", true); err != nil {
+		t.Fatalf("force delete should succeed with leftover content: %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("worktree directory should be gone after force delete, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`gren delete` ran a plain `git worktree remove`, which fails with:

```
error: failed to delete '.../worktree': Directory not empty
Use force delete to remove anyway.
```

whenever the checkout still holds gitignored build output (`node_modules/`, `.venv/`, dist, …) — i.e. any worktree that's been set up. The herdr `prefix+shift+d` flow (which runs `gren delete` without `-f`) surfaced this as a dead-end error, since the plugin can't pass force.

## Fix

Before deleting, `gren delete` now checks for content git won't remove on its own (`git status --porcelain --ignored`). If there's any, it **lists it and prompts** `Force remove (this discards the above)? [y/N]`. On yes, it forces. In a non-interactive context it returns a clear "re-run with -f" error instead.

The core force path (`DeleteWorktree(force=true)`) also gains a fallback: if `git worktree remove --force` still refuses (leftover ignored content, or a worktree left **half-removed** by a prior non-force attempt), it removes the checkout directory and runs `git worktree prune`. The branch is always preserved.

No gren-herdr change needed — the plugin already runs `gren delete` in a pane with a TTY, so the prompt appears there automatically.

## Tests

- `TestWorktreeBlockingContent`, `TestCapList` (cli).
- `TestDeleteWorktreeForceRemovesLeftoverContent` (core, integration).
- E2E: `gren delete -f` on a worktree holding `node_modules/` removes it cleanly. `go test -p 1 ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree deletion behavior when the target contains leftover files or ignored content that can block removal.
  * Added a safer confirmation flow in interactive mode and clearer guidance in non-interactive mode when a forced delete is needed.
  * Forced deletion now more reliably removes stubborn worktrees and cleans up related Git state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->