### PR TITLE
feat(cli): machine-readable output for delete and hook-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`gren delete --format=json`.** Deleting a worktree was the one destructive operation with no machine-readable path: a consumer got prose and an exit code, so each of them — the herdr plugin, the `issue-worktrees` agent skill — reimplemented gren's own safety check with `git status --porcelain` before daring to pass `-f`. JSON mode never prompts (plugins, agents, and CI cannot answer a y/N) and reports the decision as data instead: `deleted`, a `reason` from a closed set (`dry_run`, `confirmation_required`, `not_found`, `hook_failed`, `error`), and a `blocking` object when content is in the way. `blocking.tracked` lists untracked/modified entries as `{status, path}` — the porcelain code split from the path, so consumers don't each re-parse git's output format — while gitignored build output is counted rather than listed, since listing it is what buried the entries that mattered. `--dry-run --format=json` answers "is this safe to remove?" without touching anything, and `branch_kept` states gren's branch-preservation guarantee rather than leaving it implied.
+- **`gren hook-run --format=json`.** Returns `ok`, `ran`, and a `hooks[]` array with each hook's command, status, and captured output. A caller that runs setup in a pane it cannot read back (herdr's bootstrap pane) or in CI can now report which hook failed and why, instead of surfacing a bare exit code and pointing at a log file.
+
+### Changed
+
+- **In `--format=json`, stdout carries the payload and nothing else.** This previously held by discipline — remembering, at every call site however deep in the stack, not to print — and that discipline failed in 0.18.1, where a single unpushed-commits warning landed ahead of the JSON and broke every consumer piping to `jq`. Human-facing output now resolves through one sink per package, which JSON mode points at stderr for the duration of the command, so the invariant is structural rather than remembered. Progress still reaches stderr, so it stays visible in a terminal and in captured logs. Human-mode output is unchanged.
+- **`hook-run` dispatch no longer repeats itself per hook type.** All seven cases ran the same print-events-then-check-failure block; they now share one tail, which is what let JSON output be a single change rather than seven.
+
 ## [0.18.1] — 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -474,6 +474,66 @@ for when building any external consumer: `hook-run --interactive` (hooks against
 a PTY, output tee'd to both terminal and disk), `create --format=json` with a
 guaranteed-absolute `.path` and pure-JSON stdout, and `list --format=json`.
 
+## Machine-Readable Output
+
+`--format=json` is supported by `create`, `list`, `delete`, and `hook-run`. Two
+guarantees hold across all of them:
+
+- **stdout carries the payload and nothing else.** Banners, warnings, progress,
+  and hook phase summaries all go to stderr in this mode, so the output is safe
+  to pipe straight into `jq` without stripping anything first.
+- **The exit code still means what it always did.** A shell caller that only
+  checks `$?` behaves identically with and without the flag.
+
+### `delete --format=json`
+
+JSON mode never prompts — its callers are plugins, agents, and CI, none of which
+can answer a y/N. That makes `--dry-run` the way to ask whether a worktree is
+safe to remove:
+
+```bash
+gren delete --dry-run --format=json my-feature
+```
+
+```json
+{
+  "name": "my-feature",
+  "branch": "my-feature",
+  "path": "/path/to/worktrees/my-feature",
+  "deleted": false,
+  "would_force": true,
+  "branch_kept": true,
+  "reason": "dry_run",
+  "blocking": {
+    "tracked": [{ "status": "??", "path": "scratch.txt" }],
+    "ignored_count": 12
+  }
+}
+```
+
+`blocking.tracked` is work that could be lost — untracked or modified files,
+with their `git status --porcelain` code. `ignored_count` is the gitignored
+build output (`node_modules/`, `.venv/`) that any set-up worktree accumulates;
+it is counted rather than listed because listing it buried the entries that
+matter. A consumer no longer has to reimplement this check with
+`git status --porcelain` of its own.
+
+`deleted` is the only field a caller must check. When it is false, `reason` says
+why, from a closed set: `dry_run`, `confirmation_required` (no `-f`),
+`not_found`, `hook_failed`, `error`. Pass `-f` to actually delete. The branch is
+always preserved — `branch_kept` states it rather than leaving it implied.
+
+### `hook-run --format=json`
+
+```bash
+gren hook-run --type post-create --path "$WORKTREE" --branch "$BRANCH" --format=json
+```
+
+Returns `ok`, `ran`, and a `hooks[]` array carrying each hook's command, exit
+status, and captured output. This is what lets a caller that ran setup in a pane
+it cannot read — herdr's bootstrap pane, or CI — report *which* hook failed and
+why, instead of surfacing a bare exit code.
+
 ## CLI Commands
 
 ### Core Commands

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -688,6 +689,7 @@ func (c *CLI) handleDelete(args []string) error {
 	fs := flag.NewFlagSet("delete", flag.ExitOnError)
 	force := fs.Bool("f", false, "Force deletion without confirmation")
 	dryRun := fs.Bool("dry-run", false, "Show what would be deleted without actually deleting")
+	format := addFormatFlag(fs)
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: gren delete [options] <worktree-name>\n")
@@ -698,10 +700,20 @@ func (c *CLI) handleDelete(args []string) error {
 		fmt.Fprintf(fs.Output(), "  gren delete feature-branch\n")
 		fmt.Fprintf(fs.Output(), "  gren delete -f old-feature\n")
 		fmt.Fprintf(fs.Output(), "  gren delete --dry-run feature-branch\n")
+		fmt.Fprintf(fs.Output(), "  gren delete --dry-run --format=json feature-branch   # What blocks it?\n")
+		fmt.Fprintf(fs.Output(), "  gren delete -f --format=json old-feature             # Machine-readable\n")
 	}
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	jsonMode, err := parseFormat(*format)
+	if err != nil {
+		return err
+	}
+	if jsonMode {
+		defer enterJSONMode()()
 	}
 
 	if fs.NArg() == 0 {
@@ -711,28 +723,33 @@ func (c *CLI) handleDelete(args []string) error {
 	}
 
 	worktreeName := fs.Arg(0)
-	logging.Info("CLI delete: worktree=%s, force=%v, dry-run=%v", worktreeName, *force, *dryRun)
+	logging.Info("CLI delete: worktree=%s, force=%v, dry-run=%v, json=%v", worktreeName, *force, *dryRun, jsonMode)
 
-	// Dry run mode - just show what would happen
-	if *dryRun {
-		fmt.Printf("[dry-run] Would delete worktree: %s\n", worktreeName)
+	// Dry run mode - just show what would happen. In JSON mode this is the
+	// inspection call: it answers "is this worktree safe to remove, and if not,
+	// what exactly is in the way" without touching anything.
+	if *dryRun && !jsonMode {
+		fmt.Fprintf(humanOut(), "[dry-run] Would delete worktree: %s\n", worktreeName)
 		return nil
 	}
 
-	// Confirmation unless force is specified
-	if !*force {
+	// Confirmation unless force is specified. JSON mode never prompts: its
+	// callers are plugins, agents, and CI, none of which can answer. Without -f
+	// it reports what it would have asked about and exits non-zero, which is
+	// strictly more useful than the bare refusal a non-TTY got before.
+	if !*force && !*dryRun && !jsonMode {
 		// Check if we're running in an interactive terminal
 		if !term.IsTerminal(int(os.Stdin.Fd())) {
 			return fmt.Errorf("cannot delete worktree without confirmation in non-interactive mode; use -f to force")
 		}
 
-		fmt.Printf("Delete worktree '%s'? (y/N): ", worktreeName)
+		fmt.Fprintf(humanOut(), "Delete worktree '%s'? (y/N): ", worktreeName)
 		var response string
 		fmt.Scanln(&response)
 		response = strings.ToLower(strings.TrimSpace(response))
 		if response != "y" && response != "yes" {
 			logging.Info("CLI delete: user cancelled deletion of %s", worktreeName)
-			fmt.Println("Cancelled")
+			fmt.Fprintln(humanOut(), "Cancelled")
 			return nil
 		}
 		logging.Info("CLI delete: user confirmed deletion of %s", worktreeName)
@@ -743,6 +760,9 @@ func (c *CLI) handleDelete(args []string) error {
 	// Get worktree info for hook context
 	worktrees, err := c.worktreeManager.ListWorktrees(ctx)
 	if err != nil {
+		if jsonMode {
+			_ = emitJSON(DeleteJSON{Name: worktreeName, Reason: DeleteReasonError, Error: err.Error()})
+		}
 		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
 	var targetWorktree *core.WorktreeInfo
@@ -753,7 +773,34 @@ func (c *CLI) handleDelete(args []string) error {
 		}
 	}
 	if targetWorktree == nil {
+		if jsonMode {
+			_ = emitJSON(DeleteJSON{Name: worktreeName, Reason: DeleteReasonNotFound})
+		}
 		return fmt.Errorf("worktree '%s' not found", worktreeName)
+	}
+
+	// JSON mode resolves the whole decision up front — blocking content, then
+	// dry-run or missing -f — so the caller gets one object describing why
+	// nothing happened, instead of an error string it has to pattern-match.
+	if jsonMode {
+		blocking := blockingJSON(targetWorktree.Path)
+		base := DeleteJSON{
+			Name:       targetWorktree.Name,
+			Branch:     targetWorktree.Branch,
+			Path:       targetWorktree.Path,
+			BranchKept: true,
+			Blocking:   blocking,
+		}
+		switch {
+		case *dryRun:
+			base.Reason = DeleteReasonDryRun
+			base.WouldForce = blocking != nil
+			return emitJSON(base)
+		case !*force:
+			base.Reason = DeleteReasonConfirmationRequired
+			_ = emitJSON(base)
+			return fmt.Errorf("refusing to delete %q without -f: --format=json never prompts", worktreeName)
+		}
 	}
 
 	// Run pre-remove hooks with approval (interactive prompt). Stream phase
@@ -764,6 +811,17 @@ func (c *CLI) handleDelete(args []string) error {
 	c.worktreeManager.SetEventObserver(nil)
 	printHookEvents(results)
 	if failed := core.FirstFailedHook(results); failed != nil {
+		if jsonMode {
+			_ = emitJSON(DeleteJSON{
+				Name:       targetWorktree.Name,
+				Branch:     targetWorktree.Branch,
+				Path:       targetWorktree.Path,
+				BranchKept: true,
+				Reason:     DeleteReasonHookFailed,
+				Error:      failed.Err.Error(),
+				Hooks:      hookResultsToJSON(results),
+			})
+		}
 		return fmt.Errorf("pre-remove hook failed: %s\n%s", failed.Err, failed.FailureOutput())
 	}
 
@@ -781,26 +839,26 @@ func (c *CLI) handleDelete(args []string) error {
 			if len(real) == 0 {
 				// Only gitignored content blocks the removal — nothing worth a
 				// prompt after the user already confirmed the delete.
-				fmt.Printf("Worktree '%s' only contains gitignored files (%d entries) — removing them with the worktree.\n", worktreeName, len(ignored))
+				fmt.Fprintf(humanOut(), "Worktree '%s' only contains gitignored files (%d entries) — removing them with the worktree.\n", worktreeName, len(ignored))
 				logging.Info("CLI delete: auto-forcing removal of %s (%d gitignored entries)", worktreeName, len(ignored))
 				effectiveForce = true
 			} else {
 				if !term.IsTerminal(int(os.Stdin.Fd())) {
 					return fmt.Errorf("worktree '%s' has uncommitted or untracked files that block a clean delete; re-run with -f to force", worktreeName)
 				}
-				fmt.Printf("Worktree '%s' still contains files git won't remove on its own:\n", worktreeName)
+				fmt.Fprintf(humanOut(), "Worktree '%s' still contains files git won't remove on its own:\n", worktreeName)
 				for _, l := range capList(real, 15) {
-					fmt.Printf("  %s\n", l)
+					fmt.Fprintf(humanOut(), "  %s\n", l)
 				}
 				if len(ignored) > 0 {
-					fmt.Printf("  (plus %d gitignored entries that will also be removed)\n", len(ignored))
+					fmt.Fprintf(humanOut(), "  (plus %d gitignored entries that will also be removed)\n", len(ignored))
 				}
-				fmt.Print("Force remove (this discards the above)? [y/N]: ")
+				fmt.Fprint(humanOut(), "Force remove (this discards the above)? [y/N]: ")
 				var resp string
 				fmt.Scanln(&resp)
 				if r := strings.ToLower(strings.TrimSpace(resp)); r != "y" && r != "yes" {
 					logging.Info("CLI delete: user declined force removal of %s", worktreeName)
-					fmt.Println("Cancelled")
+					fmt.Fprintln(humanOut(), "Cancelled")
 					return nil
 				}
 				effectiveForce = true
@@ -811,6 +869,17 @@ func (c *CLI) handleDelete(args []string) error {
 	err = c.worktreeManager.DeleteWorktree(ctx, worktreeName, effectiveForce)
 	if err != nil {
 		logging.Error("CLI delete failed: %v", err)
+		if jsonMode {
+			_ = emitJSON(DeleteJSON{
+				Name:       targetWorktree.Name,
+				Branch:     worktreeBranch,
+				Path:       worktreePath,
+				BranchKept: true,
+				Reason:     DeleteReasonError,
+				Error:      err.Error(),
+				Hooks:      hookResultsToJSON(results),
+			})
+		}
 		return err
 	}
 
@@ -820,7 +889,110 @@ func (c *CLI) handleDelete(args []string) error {
 	postResults := c.worktreeManager.RunPostRemoveHookWithApproval(worktreePath, worktreeBranch, false)
 	c.worktreeManager.SetEventObserver(nil)
 	printHookEvents(postResults)
+
+	if jsonMode {
+		allHooks := append([]core.HookResult{}, results...)
+		allHooks = append(allHooks, postResults...)
+		return emitJSON(DeleteJSON{
+			Name:       targetWorktree.Name,
+			Branch:     worktreeBranch,
+			Path:       worktreePath,
+			Deleted:    true,
+			Forced:     effectiveForce,
+			BranchKept: true,
+			Hooks:      hookResultsToJSON(allHooks),
+		})
+	}
 	return nil
+}
+
+// Reasons reported by `gren delete --format=json` when Deleted is false. They
+// are a closed set so a caller can switch on them instead of matching error
+// prose, which is free to change.
+const (
+	DeleteReasonDryRun               = "dry_run"
+	DeleteReasonConfirmationRequired = "confirmation_required"
+	DeleteReasonBlocked              = "blocked"
+	DeleteReasonNotFound             = "not_found"
+	DeleteReasonHookFailed           = "hook_failed"
+	DeleteReasonError                = "error"
+)
+
+// DeleteJSON is the machine-readable shape returned by `gren delete --format=json`.
+//
+// Deleted is the single field a caller has to check. When it is false, Reason
+// says why in a stable vocabulary and Blocking carries the detail — so an agent
+// deciding whether a worktree is safe to remove can ask gren instead of
+// reimplementing the check with `git status --porcelain`, which is what every
+// consumer had to do before this existed.
+type DeleteJSON struct {
+	Name    string `json:"name"`
+	Branch  string `json:"branch,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Deleted bool   `json:"deleted"`
+	Forced  bool   `json:"forced,omitempty"`
+	// WouldForce reports, for a dry run, whether the real delete would need -f.
+	WouldForce bool `json:"would_force,omitempty"`
+	// BranchKept is always true: gren preserves the branch by design. It is
+	// stated rather than implied so callers don't guess.
+	BranchKept bool          `json:"branch_kept"`
+	Reason     string        `json:"reason,omitempty"`
+	Blocking   *BlockingJSON `json:"blocking,omitempty"`
+	Hooks      []HookJSON    `json:"hooks,omitempty"`
+	Error      string        `json:"error,omitempty"`
+}
+
+// BlockingJSON describes content that stops a plain `git worktree remove`.
+//
+// The split matters: Tracked entries are work that could be lost and warrant a
+// human decision, while Ignored is build output (node_modules/, .venv/) that
+// any set-up worktree accumulates and nobody needs to see listed. Only the
+// count is reported for the latter — listing them was noise that hid the
+// entries that actually matter.
+type BlockingJSON struct {
+	Tracked      []BlockingEntry `json:"tracked,omitempty"`
+	IgnoredCount int             `json:"ignored_count"`
+}
+
+// BlockingEntry is one piece of content in the way of a removal.
+//
+// Status is the two-character `git status --porcelain` code (`??` untracked,
+// ` M` modified, `A ` added, …) and Path is what it refers to. They are split
+// rather than handed over as one porcelain line so a caller can show the path
+// without re-parsing a git output format — leaking that format into the payload
+// would make every consumer implement the same two-character slice.
+type BlockingEntry struct {
+	Status string `json:"status"`
+	Path   string `json:"path"`
+}
+
+// blockingJSON inspects a worktree path and reports what would block removal,
+// or nil when a plain remove would succeed.
+func blockingJSON(worktreePath string) *BlockingJSON {
+	leftovers := worktreeBlockingContent(worktreePath)
+	if len(leftovers) == 0 {
+		return nil
+	}
+	real, ignored := splitBlockingContent(leftovers)
+	entries := make([]BlockingEntry, 0, len(real))
+	for _, l := range real {
+		entries = append(entries, parseBlockingEntry(l))
+	}
+	return &BlockingJSON{Tracked: entries, IgnoredCount: len(ignored)}
+}
+
+// parseBlockingEntry splits a porcelain line into its status code and path.
+// A line too short for the fixed "XY path" shape is passed through as the path
+// with an empty status rather than dropped: an entry the caller cannot classify
+// is still an entry it must not silently delete.
+func parseBlockingEntry(line string) BlockingEntry {
+	if len(line) < 4 {
+		return BlockingEntry{Path: strings.TrimSpace(line)}
+	}
+	return BlockingEntry{
+		Status: line[:2],
+		Path:   strings.TrimSpace(line[3:]),
+	}
 }
 
 // handleCleanup handles the cleanup command (delete all stale worktrees)
@@ -2726,9 +2898,18 @@ func (c *CLI) handleHookRun(args []string) error {
 	baseBranch := fs.String("base", "", "Base branch")
 	interactive := fs.Bool("interactive", false, "Force all hooks to run with terminal access (inherited stdio) and prompt for approval")
 	tty := fs.Bool("tty", false, "Alias for --interactive")
+	format := addFormatFlag(fs)
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	jsonMode, err := parseFormat(*format)
+	if err != nil {
+		return err
+	}
+	if jsonMode {
+		defer enterJSONMode()()
 	}
 
 	if *hookType == "" {
@@ -2755,62 +2936,89 @@ func (c *CLI) handleHookRun(args []string) error {
 	c.worktreeManager.SetEventObserver(streamEventsTo(os.Stderr))
 	defer c.worktreeManager.SetEventObserver(nil)
 
+	// Each case only differs in which runner it calls and whether a failure is
+	// fatal, so dispatch produces results and the shared tail handles reporting.
+	// Before, every case repeated the same printHookEvents/HooksFailed block,
+	// and adding JSON output would have meant repeating it seven more times.
+	var results []core.HookResult
+	bestEffort := false
+
 	switch ht {
 	case config.HookPostCreate:
-		results := c.worktreeManager.RunPostCreateHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPostCreateHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
 	case config.HookPreRemove:
-		results := c.worktreeManager.RunPreRemoveHookWithApproval(*worktreePath, *branchName, autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPreRemoveHookWithApproval(*worktreePath, *branchName, autoApprove)
 	case config.HookPostRemove:
 		// post-remove is best-effort; errors are logged but not returned
-		results := c.worktreeManager.RunPostRemoveHookWithApproval(*worktreePath, *branchName, autoApprove)
-		printHookEvents(results)
+		results = c.worktreeManager.RunPostRemoveHookWithApproval(*worktreePath, *branchName, autoApprove)
+		bestEffort = true
 	case config.HookPreMerge:
-		results := c.worktreeManager.RunPreMergeHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPreMergeHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
 	case config.HookPostMerge:
-		results := c.worktreeManager.RunPostMergeHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPostMergeHookWithApproval(*worktreePath, *branchName, *baseBranch, autoApprove)
 	case config.HookPostSwitch:
-		results := c.worktreeManager.RunPostSwitchHookWithApproval(*worktreePath, *branchName, autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPostSwitchHookWithApproval(*worktreePath, *branchName, autoApprove)
 	case config.HookPostStart:
-		results := c.worktreeManager.RunPostStartHookWithApproval(*worktreePath, *branchName, "", autoApprove)
-		printHookEvents(results)
-		if core.HooksFailed(results) {
-			if failed := core.FirstFailedHook(results); failed != nil {
-				return fmt.Errorf("hook failed: %v", failed.Err)
-			}
-		}
+		results = c.worktreeManager.RunPostStartHookWithApproval(*worktreePath, *branchName, "", autoApprove)
 	default:
+		if jsonMode {
+			_ = emitJSON(HookRunJSON{Type: *hookType, Branch: *branchName, Path: *worktreePath,
+				Error: fmt.Sprintf("unknown hook type: %s", *hookType)})
+		}
 		return fmt.Errorf("unknown hook type: %s", *hookType)
 	}
 
+	printHookEvents(results)
+
+	failed := core.FirstFailedHook(results)
+	fatal := failed != nil && !bestEffort
+
+	if jsonMode {
+		out := HookRunJSON{
+			Type:   *hookType,
+			Branch: *branchName,
+			Path:   *worktreePath,
+			Ok:     failed == nil,
+			Ran:    len(results) > 0,
+			Hooks:  hookResultsToJSON(results),
+		}
+		if failed != nil {
+			out.Error = failed.Err.Error()
+		}
+		if err := emitJSON(out); err != nil {
+			return err
+		}
+		// The payload already carries the failure; still exit non-zero so a
+		// shell caller that only checks $? behaves the same as without --format.
+		if fatal {
+			return errHookFailedSilently
+		}
+		return nil
+	}
+
+	if fatal {
+		return fmt.Errorf("hook failed: %v", failed.Err)
+	}
 	return nil
+}
+
+// errHookFailedSilently marks a failure whose detail has already been written
+// to stdout as JSON. main prints errors to stderr; this one carries no message
+// because repeating it would just be noise beside the payload.
+var errHookFailedSilently = errors.New("")
+
+// HookRunJSON is the machine-readable shape returned by `gren hook-run --format=json`.
+//
+// Ok is the field to check. Hooks carries per-hook detail — including captured
+// output — so a caller that ran setup in a pane it cannot read (herdr's
+// bootstrap pane, CI) can still report exactly which hook failed and why,
+// instead of surfacing a bare exit code.
+type HookRunJSON struct {
+	Type   string     `json:"type"`
+	Branch string     `json:"branch,omitempty"`
+	Path   string     `json:"path,omitempty"`
+	Ok     bool       `json:"ok"`
+	Ran    bool       `json:"ran"`
+	Hooks  []HookJSON `json:"hooks,omitempty"`
+	Error  string     `json:"error,omitempty"`
 }

--- a/internal/cli/hook_events.go
+++ b/internal/cli/hook_events.go
@@ -50,9 +50,12 @@ func streamEventsTo(w io.Writer) func(events.Event) {
 	}
 }
 
-// printHookEvents writes a phase summary to stdout whenever any hook in
-// results produced events. Always runs — on success so the user sees what
-// the hook actually did, and on failure so interrupted phases are visible.
+// printHookEvents writes a phase summary whenever any hook in results produced
+// events. Always runs — on success so the user sees what the hook actually did,
+// and on failure so interrupted phases are visible.
+//
+// Writes to humanOut, not stdout: in JSON mode the same phases are carried
+// inside the payload, and printing them again on stdout would corrupt it.
 func printHookEvents(results []core.HookResult) {
 	var all []events.Event
 	var files []string
@@ -67,17 +70,17 @@ func printHookEvents(results []core.HookResult) {
 		return
 	}
 	if len(all) > 0 {
-		fmt.Println()
-		fmt.Println("Hook phases:")
+		fmt.Fprintln(humanOut())
+		fmt.Fprintln(humanOut(), "Hook phases:")
 		for _, e := range all {
-			fmt.Println(RenderEventLine(e))
+			fmt.Fprintln(humanOut(), RenderEventLine(e))
 		}
 	}
 	if failed && len(files) > 0 {
-		fmt.Println()
-		fmt.Println("Hook failed. Event log for post-mortem:")
+		fmt.Fprintln(humanOut())
+		fmt.Fprintln(humanOut(), "Hook failed. Event log for post-mortem:")
 		for _, f := range files {
-			fmt.Println("  " + f)
+			fmt.Fprintln(humanOut(), "  "+f)
 		}
 	}
 }

--- a/internal/cli/json_output_test.go
+++ b/internal/cli/json_output_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/langtind/gren/internal/config"
+	"github.com/langtind/gren/internal/core"
+	"github.com/langtind/gren/internal/events"
+	"github.com/langtind/gren/internal/git"
+)
+
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		format   string
+		wantJSON bool
+		wantErr  bool
+	}{
+		{"", false, false},
+		{"json", true, false},
+		{"JSON", false, true},  // case-sensitive on purpose: no silent near-misses
+		{"yaml", false, true},  // unsupported must fail loudly, not fall back to prose
+		{"table", false, true}, // ditto
+	}
+	for _, tt := range tests {
+		got, err := parseFormat(tt.format)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseFormat(%q) error = %v, wantErr %v", tt.format, err, tt.wantErr)
+		}
+		if got != tt.wantJSON {
+			t.Errorf("parseFormat(%q) = %v, want %v", tt.format, got, tt.wantJSON)
+		}
+	}
+}
+
+// TestPrintHookEventsWritesToHumanOut guards the mechanism that keeps JSON
+// stdout clean. Hook phase summaries are the largest chunk of prose gren emits
+// during a delete, and they used to go to stdout unconditionally.
+func TestPrintHookEventsWritesToHumanOut(t *testing.T) {
+	var buf bytes.Buffer
+	prev := humanOutOverride
+	humanOutOverride = &buf
+	defer func() { humanOutOverride = prev }()
+
+	results := []core.HookResult{{
+		Name:   "setup",
+		Ran:    true,
+		Events: []events.Event{{Phase: "install", Status: events.StatusOK}},
+	}}
+
+	stdout := captureStdout(t, func() { printHookEvents(results) })
+
+	if stdout != "" {
+		t.Errorf("printHookEvents wrote to stdout: %q — this corrupts --format=json payloads", stdout)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("install")) {
+		t.Errorf("printHookEvents did not write the phase to humanOut, got %q", buf.String())
+	}
+}
+
+// deleteJSONRepo builds a repo with one worktree and returns the repo dir, the
+// worktree name, and its path.
+func deleteJSONRepo(t *testing.T, name string) (repoDir, worktreePath string) {
+	t.Helper()
+	dir, cleanup := setupTempGitRepoWithCleanWorktrees(t)
+	t.Cleanup(cleanup)
+
+	originalDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(originalDir) })
+	os.Chdir(dir)
+
+	config.Initialize(filepath.Base(dir), true)
+	cli := NewCLI(git.NewLocalRepository(), config.NewManager())
+
+	out := captureStdout(t, func() {
+		if err := cli.ParseAndExecute([]string{"gren", "create", "-n", name, "--no-hooks", "-y", "--format=json"}); err != nil {
+			t.Fatalf("create %s failed: %v", name, err)
+		}
+	})
+	var created CreateJSON
+	if err := json.Unmarshal([]byte(out), &created); err != nil {
+		t.Fatalf("parse create JSON %q: %v", out, err)
+	}
+	return dir, created.Path
+}
+
+// runDeleteJSON runs `gren delete` with the given args and returns the parsed
+// payload plus whether the command errored. It fails the test if stdout is not
+// pure JSON — the invariant every one of these cases has to hold.
+func runDeleteJSON(t *testing.T, args ...string) (DeleteJSON, bool) {
+	t.Helper()
+	cli := NewCLI(git.NewLocalRepository(), config.NewManager())
+
+	var cmdErr error
+	stdout := captureStdout(t, func() {
+		captureStderr(t, func() {
+			cmdErr = cli.ParseAndExecute(append([]string{"gren", "delete"}, args...))
+		})
+	})
+
+	var result DeleteJSON
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("delete --format=json stdout must be pure JSON, got parse error %v\nstdout: %q", err, stdout)
+	}
+	return result, cmdErr != nil
+}
+
+// TestDeleteJSONDryRunReportsBlockingContent is the case that makes this flag
+// worth having: an agent asking "is this worktree safe to remove?" gets a
+// structured answer instead of having to reimplement the check with
+// `git status --porcelain`, and nothing is touched.
+func TestDeleteJSONDryRunReportsBlockingContent(t *testing.T) {
+	_, worktreePath := deleteJSONRepo(t, "dry-run-blocked")
+
+	// An untracked file is exactly what should stop an unattended delete.
+	if err := os.WriteFile(filepath.Join(worktreePath, "scratch.txt"), []byte("work in progress\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, errored := runDeleteJSON(t, "--dry-run", "--format=json", "dry-run-blocked")
+
+	if errored {
+		t.Errorf("a dry run must not fail; it is an inspection")
+	}
+	if result.Deleted {
+		t.Errorf("dry run reported deleted=true")
+	}
+	if result.Reason != DeleteReasonDryRun {
+		t.Errorf("reason = %q, want %q", result.Reason, DeleteReasonDryRun)
+	}
+	if result.Blocking == nil || len(result.Blocking.Tracked) == 0 {
+		t.Fatalf("untracked file was not reported as blocking: %+v", result.Blocking)
+	}
+	var found bool
+	for _, e := range result.Blocking.Tracked {
+		if e.Path == "scratch.txt" {
+			found = true
+			if e.Status != "??" {
+				t.Errorf("status = %q, want %q for an untracked file", e.Status, "??")
+			}
+		}
+		if strings.HasPrefix(e.Path, "?") {
+			t.Errorf("path %q still carries the porcelain prefix; status belongs in .status", e.Path)
+		}
+	}
+	if !found {
+		t.Errorf("scratch.txt missing from blocking.tracked: %+v", result.Blocking.Tracked)
+	}
+	if !result.WouldForce {
+		t.Errorf("would_force should be true when content blocks removal")
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("dry run removed the worktree: %v", err)
+	}
+}
+
+// TestDeleteJSONWithoutForceRefuses locks in that JSON mode never prompts.
+// Its callers — plugins, agents, CI — cannot answer a y/N, and a prompt that
+// nobody answers is a hang, not a safety feature.
+func TestDeleteJSONWithoutForceRefuses(t *testing.T) {
+	_, worktreePath := deleteJSONRepo(t, "no-force")
+
+	result, errored := runDeleteJSON(t, "--format=json", "no-force")
+
+	if !errored {
+		t.Errorf("delete --format=json without -f must exit non-zero")
+	}
+	if result.Deleted {
+		t.Errorf("deleted=true without -f")
+	}
+	if result.Reason != DeleteReasonConfirmationRequired {
+		t.Errorf("reason = %q, want %q", result.Reason, DeleteReasonConfirmationRequired)
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree was removed despite the refusal: %v", err)
+	}
+}
+
+// TestDeleteJSONForceDeletes covers the happy path and the branch_kept promise.
+func TestDeleteJSONForceDeletes(t *testing.T) {
+	_, worktreePath := deleteJSONRepo(t, "force-delete")
+
+	result, errored := runDeleteJSON(t, "-f", "--format=json", "force-delete")
+
+	if errored {
+		t.Fatalf("delete -f --format=json failed")
+	}
+	if !result.Deleted {
+		t.Errorf("deleted=false after a forced delete: %+v", result)
+	}
+	if !result.BranchKept {
+		t.Errorf("branch_kept must be true — gren preserves the branch by design")
+	}
+	if result.Path == "" {
+		t.Errorf("path is empty; callers need it to close the matching herdr workspace")
+	}
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Errorf("worktree still on disk after deleted=true: %v", err)
+	}
+}
+
+// TestDeleteJSONNotFound checks the closed reason vocabulary holds for the
+// case a caller hits most often after a manual cleanup.
+func TestDeleteJSONNotFound(t *testing.T) {
+	deleteJSONRepo(t, "exists")
+
+	result, errored := runDeleteJSON(t, "-f", "--format=json", "no-such-worktree")
+
+	if !errored {
+		t.Errorf("deleting a missing worktree must exit non-zero")
+	}
+	if result.Reason != DeleteReasonNotFound {
+		t.Errorf("reason = %q, want %q", result.Reason, DeleteReasonNotFound)
+	}
+}
+
+// hookRunJSONRepo builds a repo whose post-create hook is the given shell
+// command, then returns the repo dir and a created worktree path.
+func hookRunJSONRepo(t *testing.T, name, hookCmd string) (repoDir, worktreePath string) {
+	t.Helper()
+	dir, worktreePath := deleteJSONRepo(t, name)
+
+	cfg := "version = \"" + config.CurrentConfigVersion + "\"\n" +
+		"worktree_dir = \"" + filepath.Join(filepath.Dir(dir), filepath.Base(dir)+"-worktrees") + "\"\n" +
+		"[hooks]\npost-create = \"" + hookCmd + "\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gren", "config.toml"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, worktreePath
+}
+
+// runHookRunJSON runs `gren hook-run --format=json` and asserts stdout parses.
+func runHookRunJSON(t *testing.T, args ...string) (HookRunJSON, bool) {
+	t.Helper()
+	cli := NewCLI(git.NewLocalRepository(), config.NewManager())
+
+	var cmdErr error
+	stdout := captureStdout(t, func() {
+		captureStderr(t, func() {
+			cmdErr = cli.ParseAndExecute(append([]string{"gren", "hook-run"}, args...))
+		})
+	})
+
+	var result HookRunJSON
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("hook-run --format=json stdout must be pure JSON, got parse error %v\nstdout: %q", err, stdout)
+	}
+	return result, cmdErr != nil
+}
+
+// TestHookRunJSONReportsSuccess covers the call herdr's bootstrap pane makes.
+// Today it learns only an exit code; with --format=json it can report which
+// hook ran and what it printed.
+func TestHookRunJSONReportsSuccess(t *testing.T) {
+	_, worktreePath := hookRunJSONRepo(t, "hook-ok", "echo setup-done")
+
+	result, errored := runHookRunJSON(t, "--type", "post-create", "--path", worktreePath,
+		"--branch", "hook-ok", "--format=json")
+
+	if errored {
+		t.Fatalf("a succeeding hook must exit zero: %+v", result)
+	}
+	if !result.Ok {
+		t.Errorf("ok=false for a succeeding hook: %+v", result)
+	}
+	if !result.Ran {
+		t.Errorf("ran=false although a hook is configured")
+	}
+	if result.Type != "post-create" {
+		t.Errorf("type = %q, want post-create", result.Type)
+	}
+}
+
+// TestHookRunJSONReportsFailure is the case that matters in a pane nobody is
+// watching: the payload has to carry the reason, and the exit code still has
+// to be non-zero so shell callers behave unchanged.
+func TestHookRunJSONReportsFailure(t *testing.T) {
+	_, worktreePath := hookRunJSONRepo(t, "hook-fail", "exit 3")
+
+	result, errored := runHookRunJSON(t, "--type", "post-create", "--path", worktreePath,
+		"--branch", "hook-fail", "--format=json")
+
+	if !errored {
+		t.Errorf("a failing hook must still exit non-zero in JSON mode")
+	}
+	if result.Ok {
+		t.Errorf("ok=true for a failing hook: %+v", result)
+	}
+	if result.Error == "" {
+		t.Errorf("error is empty; the payload must say why the hook failed")
+	}
+	if len(result.Hooks) == 0 {
+		t.Errorf("hooks[] is empty; per-hook detail is the point of the flag")
+	}
+}
+
+// TestHookRunJSONUnknownTypeIsStructured keeps the error path parseable too —
+// a caller should never have to switch between "parse JSON" and "read prose"
+// depending on whether its arguments were right.
+func TestHookRunJSONUnknownTypeIsStructured(t *testing.T) {
+	_, worktreePath := deleteJSONRepo(t, "hook-unknown")
+
+	result, errored := runHookRunJSON(t, "--type", "post-nonsense", "--path", worktreePath,
+		"--branch", "hook-unknown", "--format=json")
+
+	if !errored {
+		t.Errorf("an unknown hook type must exit non-zero")
+	}
+	if result.Error == "" {
+		t.Errorf("error is empty for an unknown hook type")
+	}
+}

--- a/internal/cli/jsonmode.go
+++ b/internal/cli/jsonmode.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/langtind/gren/internal/output"
+)
+
+// humanOutOverride redirects this package's human-facing chatter — phase
+// summaries, prompts, progress notes. It is nil normally and os.Stderr while a
+// --format=json command is running.
+//
+// Machine output never goes through here: a JSON payload is written straight to
+// os.Stdout by emitJSON, which is the whole point of the split.
+var humanOutOverride io.Writer
+
+// humanOut resolves the sink at call time. Binding os.Stdout once at package
+// init would ignore any later reassignment of it, which is precisely what the
+// capture helpers in this package's tests do.
+func humanOut() io.Writer {
+	if humanOutOverride != nil {
+		return humanOutOverride
+	}
+	return os.Stdout
+}
+
+// addFormatFlag registers the shared --format flag on fs. Every machine-readable
+// command spells it the same way, so `--format=json` means the same thing across
+// create, list, delete, and hook-run.
+func addFormatFlag(fs *flag.FlagSet) *string {
+	return fs.String("format", "", "Output format: json for machine-readable output")
+}
+
+// parseFormat resolves --format into a bool, rejecting anything we don't emit
+// rather than silently falling back to human output — a caller that asked for
+// json and got prose would otherwise discover the mistake by parse failure.
+func parseFormat(format string) (bool, error) {
+	switch format {
+	case "":
+		return false, nil
+	case "json":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unsupported format %q; supported formats: json", format)
+	}
+}
+
+// enterJSONMode hands stdout to the JSON payload alone: this package's chatter
+// and everything the output package prints are both redirected to stderr for
+// the duration. The returned function restores both.
+//
+// The invariant it buys — in JSON mode, stdout carries the payload and nothing
+// else — is what makes the output parseable without the caller having to strip
+// banners, warnings, or hook phase lines. Progress still reaches stderr, so it
+// stays visible in a terminal and in captured logs.
+//
+// Callers use it as:
+//
+//	if jsonMode {
+//	    defer enterJSONMode()()
+//	}
+func enterJSONMode() func() {
+	prevHuman := humanOutOverride
+	humanOutOverride = os.Stderr
+	restoreOutput := output.SetStdout(os.Stderr)
+	return func() {
+		humanOutOverride = prevHuman
+		restoreOutput()
+	}
+}
+
+// emitJSON writes v to real stdout as indented JSON with a trailing newline.
+// It deliberately takes os.Stdout rather than humanOut: this is the payload,
+// and it must land on stdout even while every human-facing writer points at
+// stderr.
+func emitJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -3,12 +3,48 @@ package output
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
+
+// stdout is where human-facing output goes. Every function in this package
+// writes here rather than to os.Stdout directly, so a caller that owns stdout —
+// notably a `--format=json` command, whose stdout must contain nothing but the
+// payload — can redirect all of it in one call.
+//
+// This exists because the alternative is discipline: remembering, at every call
+// site however deep in the stack, not to print. That failed once already in
+// 0.18.1, where a single unpushed-commits warning landed on stdout ahead of the
+// JSON object and broke every consumer piping to jq.
+//
+// Errors are exempt: Error/Errorf always write to stderr, in both modes.
+var stdoutOverride io.Writer
+
+// stdout resolves the current sink at call time rather than capturing
+// os.Stdout once at package init. That distinction matters: a caller that
+// reassigns os.Stdout — every test in this repo that captures output does —
+// must still be honoured, or this package would keep writing to the original
+// file descriptor and the capture would come back empty.
+func stdout() io.Writer {
+	if stdoutOverride != nil {
+		return stdoutOverride
+	}
+	return os.Stdout
+}
+
+// SetStdout redirects this package's human-facing output. It returns a function
+// that restores the previous writer, so callers can scope the change:
+//
+//	defer output.SetStdout(os.Stderr)()
+func SetStdout(w io.Writer) func() {
+	prev := stdoutOverride
+	stdoutOverride = w
+	return func() { stdoutOverride = prev }
+}
 
 // Symbols for message prefixes
 const (
@@ -57,7 +93,7 @@ var (
 
 // Success prints a success message with green checkmark
 func Success(message string) {
-	fmt.Println(successStyle.Render("✅") + " " + greenStyle.Render(message))
+	fmt.Fprintln(stdout(), successStyle.Render("✅")+" "+greenStyle.Render(message))
 }
 
 // Successf prints a formatted success message
@@ -77,7 +113,7 @@ func Errorf(format string, args ...interface{}) {
 
 // Warning prints a warning message with yellow triangle
 func Warning(message string) {
-	fmt.Println(warningStyle.Render("⚠️") + " " + yellowStyle.Render(message))
+	fmt.Fprintln(stdout(), warningStyle.Render("⚠️")+" "+yellowStyle.Render(message))
 }
 
 // Warningf prints a formatted warning message
@@ -87,7 +123,7 @@ func Warningf(format string, args ...interface{}) {
 
 // Progress prints a progress message with cyan circle
 func Progress(message string) {
-	fmt.Println(progressStyle.Render("⏳") + " " + cyanStyle.Render(message))
+	fmt.Fprintln(stdout(), progressStyle.Render("⏳")+" "+cyanStyle.Render(message))
 }
 
 // Progressf prints a formatted progress message
@@ -97,7 +133,7 @@ func Progressf(format string, args ...interface{}) {
 
 // Hint prints a hint message with dim arrow
 func Hint(message string) {
-	fmt.Println(hintStyle.Render("💡") + " " + dimStyle.Render(message))
+	fmt.Fprintln(stdout(), hintStyle.Render("💡")+" "+dimStyle.Render(message))
 }
 
 // Hintf prints a formatted hint message
@@ -107,7 +143,7 @@ func Hintf(format string, args ...interface{}) {
 
 // Info prints an info message with dim circle
 func Info(message string) {
-	fmt.Println(infoStyle.Render(SymbolInfo) + " " + message)
+	fmt.Fprintln(stdout(), infoStyle.Render(SymbolInfo)+" "+message)
 }
 
 // Infof prints a formatted info message
@@ -117,7 +153,7 @@ func Infof(format string, args ...interface{}) {
 
 // Header prints a section header
 func Header(title string) {
-	fmt.Println(headerStyle.Render(title))
+	fmt.Fprintln(stdout(), headerStyle.Render(title))
 }
 
 // Bold returns bolded text
@@ -166,7 +202,7 @@ func Branch(name string) string {
 
 // KeyValue prints a key-value pair with proper formatting
 func KeyValue(key, value string) {
-	fmt.Printf("%s %s\n", dimStyle.Render(key+":"), value)
+	fmt.Fprintf(stdout(), "%s %s\n", dimStyle.Render(key+":"), value)
 }
 
 // ListItem prints a list item with bullet
@@ -175,17 +211,17 @@ func ListItem(text string, current bool) {
 	if current {
 		prefix = greenStyle.Render("▸ ")
 	}
-	fmt.Printf("%s%s\n", prefix, text)
+	fmt.Fprintf(stdout(), "%s%s\n", prefix, text)
 }
 
 // Blank prints an empty line
 func Blank() {
-	fmt.Println()
+	fmt.Fprintln(stdout())
 }
 
 // WorktreeHeader prints the header for worktree operations
 func WorktreeHeader(repoName string) {
-	fmt.Println(cyanStyle.Render(SymbolTree) + " " + Bold("Git Worktree Manager"))
+	fmt.Fprintln(stdout(), cyanStyle.Render(SymbolTree)+" "+Bold("Git Worktree Manager"))
 	KeyValue("Project", repoName)
 	Blank()
 }
@@ -194,14 +230,14 @@ func WorktreeHeader(repoName string) {
 func WorktreeCreated(name, branch, path string) {
 	Success("Worktree created")
 	Blank()
-	fmt.Println("🌿 " + Branch(branch))
-	fmt.Println("📂 " + Path(path))
+	fmt.Fprintln(stdout(), "🌿 "+Branch(branch))
+	fmt.Fprintln(stdout(), "📂 "+Path(path))
 }
 
 // WorktreeSwitched prints info when switching to a worktree
 func WorktreeSwitched(name, path string) {
 	Successf("Switched to %s", Bold(name))
-	fmt.Println("📂 " + Path(path))
+	fmt.Fprintln(stdout(), "📂 "+Path(path))
 }
 
 // WorktreeRemoved prints info when removing a worktree
@@ -280,11 +316,11 @@ func PrintWorktreeList(items []WorktreeListItem, repoName string) {
 			indicatorStr = " " + dimStyle.Render("[") + strings.Join(indicators, " ") + dimStyle.Render("]")
 		}
 
-		fmt.Printf("%s%s%s\n", prefix, name, indicatorStr)
+		fmt.Fprintf(stdout(), "%s%s%s\n", prefix, name, indicatorStr)
 
 		// Add path on second line for verbose mode or current worktree
 		if item.IsCurrent || i == 0 {
-			fmt.Printf("   %s\n", Path(item.Path))
+			fmt.Fprintf(stdout(), "   %s\n", Path(item.Path))
 		}
 	}
 }
@@ -316,7 +352,7 @@ func PrintSimpleWorktreeList(items []WorktreeListItem) {
 			ciIcon = " " + yellowStyle.Render("●")
 		}
 
-		fmt.Printf("%s%s%s%s\n", prefix, name, staleInfo, ciIcon)
+		fmt.Fprintf(stdout(), "%s%s%s%s\n", prefix, name, staleInfo, ciIcon)
 	}
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -420,3 +420,47 @@ func TestRepoName(t *testing.T) {
 		})
 	}
 }
+
+// TestSetStdoutRedirectsAndRestores covers the seam that lets a --format=json
+// command own stdout: every human-facing writer in this package has to follow
+// the redirect, and the restore must put it back so a later command in the same
+// process is not left writing to the wrong stream.
+func TestSetStdoutRedirectsAndRestores(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetStdout(&buf)
+
+	Success("created")
+	Warning("careful")
+	Info("detail")
+	KeyValue("Project", "demo")
+	Blank()
+
+	if buf.Len() == 0 {
+		t.Fatal("SetStdout did not capture any output")
+	}
+	for _, want := range []string{"created", "careful", "detail", "Project"} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("redirected output is missing %q, got %q", want, buf.String())
+		}
+	}
+
+	restore()
+	if stdoutOverride != nil {
+		t.Error("restore did not clear the override")
+	}
+	if stdout() != os.Stdout {
+		t.Error("restore did not put the sink back to os.Stdout")
+	}
+}
+
+// TestStdoutFollowsReassignedOsStdout is the regression the first version of
+// this package got wrong: binding os.Stdout into a package var at init makes
+// every later reassignment invisible, so a caller capturing output — every test
+// helper in this repo — silently gets nothing while the text goes to the
+// process's original file descriptor.
+func TestStdoutFollowsReassignedOsStdout(t *testing.T) {
+	captured := captureStdout(func() { Success("visible") })
+	if !strings.Contains(captured, "visible") {
+		t.Errorf("output did not follow the reassigned os.Stdout, got %q", captured)
+	}
+}


### PR DESCRIPTION
`delete` was the one destructive operation with no machine-readable path. Consumers got prose and an exit code, so each of them — the herdr plugin, the `issue-worktrees` agent skill — reimplemented gren's own safety check with `git status --porcelain` before daring to pass `-f`.

## `delete --format=json`

Never prompts: its callers are plugins, agents, and CI, none of which can answer a y/N. It reports the decision as data instead.

```console
$ gren delete --dry-run --format=json my-feature
{
  "name": "my-feature",
  "deleted": false,
  "would_force": true,
  "branch_kept": true,
  "reason": "dry_run",
  "blocking": {
    "tracked": [{ "status": "??", "path": "scratch.txt" }],
    "ignored_count": 12
  }
}
```

- `deleted` is the only field a caller must check; `reason` comes from a closed set (`dry_run`, `confirmation_required`, `not_found`, `hook_failed`, `error`) so consumers switch on it instead of matching error prose.
- `blocking.tracked` splits the porcelain code from the path, so consumers don't each re-implement the same two-character slice. Gitignored build output is counted, not listed — listing it is what buried the entries that mattered.
- `branch_kept` states gren's branch-preservation guarantee rather than leaving it implied.

## `hook-run --format=json`

Returns `ok`, `ran`, and a `hooks[]` array with each hook's command, status, and captured output — so a caller that ran setup in a pane it cannot read back (herdr's bootstrap pane) or in CI can report *which* hook failed and why.

## The invariant underneath

In JSON mode, stdout carries the payload and nothing else. That previously held by discipline — remembering, at every call site however deep in the stack, not to print — and the discipline failed in 0.18.1, where one unpushed-commits warning landed ahead of the JSON and broke every consumer piping to `jq`. Human output now resolves through a single sink per package which JSON mode points at stderr for the duration of the command. 0.18.1 fixed one instance; this removes the class.

Exit codes are unchanged: a shell caller that only checks `$?` behaves identically with and without the flag.

## Notes for review

- The sink resolves **lazily** rather than binding `os.Stdout` at init. The first version bound it eagerly, which silently ignored every later reassignment of `os.Stdout` and broke three existing capture-based tests — worth knowing, because it is the same trap for any future package-level writer here.
- `hook-run`'s seven dispatch cases each repeated the same print-events-then-check-failure block; they now share one tail. That is what made JSON output a single change rather than seven.

## Tests

11 new tests: the reason vocabulary, the blocking shape, the refusal without `-f`, the force path (worktree gone, branch kept), hook success/failure/unknown-type, and the redirect mechanism itself. Every JSON case asserts stdout parses — that is the actual contract. Full suite green, `gofmt` and `go vet` clean.

Verified end-to-end against a real repo with a built binary, not just in tests.